### PR TITLE
Streamline commmand execution method

### DIFF
--- a/aioguardian/device.py
+++ b/aioguardian/device.py
@@ -1,19 +1,14 @@
 """Define device info-related API endpoints."""
-from typing import Callable, Coroutine
+from typing import Callable
 
 
 class Device:  # pylint: disable=too-few-public-methods
     """Define the endpoint manager."""
 
-    def __init__(
-        self,
-        async_execute_command: Callable[..., Coroutine],
-        create_or_run_future: Callable,
-    ):
+    def __init__(self, execute_command: Callable):
         """Initialize."""
-        self._async_execute_command = async_execute_command
-        self._create_or_run_future = create_or_run_future
+        self._execute_command = execute_command
 
     def ping(self):
         """Ping the device."""
-        return self._create_or_run_future(self._async_execute_command(0))
+        return self._execute_command(0)

--- a/examples/test_client_async.py
+++ b/examples/test_client_async.py
@@ -13,7 +13,7 @@ async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.DEBUG)
 
-    client = Client("<IP ADDRESS>")
+    client = Client("<IP ADDRESS>", use_async=True)
 
     start = time.time()
 


### PR DESCRIPTION
**Describe what the PR does:**

Previously, the `Client` object was injecting two methods into its composed objects: one to run a command against the Guardian device and one to wrap that command in a Future for `asyncio` use. This was bad: composed objects should have no knowledge of the `Client`'s internal workings like that. This PR streamlines things.

Additionally, this fixes a small bug in the async client example.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
