### PR TITLE
Create async context manager for `Client` objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,34 @@ from aioguardian import Client
 from aioguardian.errors import GuardianError
 
 
+async with Client("192.168.1.100") as client:
+    # Run various commands:
+    await client.device.ping()
+    await client.device.diagnostics()
+
+
+asyncio.run(main())
+```
+
+If the mood should strike you, you can manually instantiate a `Client` object and manage
+connection to and disconnection from the device yourself:
+
+```python
+import asyncio
+
+from aioguardian import Client
+from aioguardian.errors import GuardianError
+
+
 # Create a client with the IP address or hostname of your Guardian device:
-client = Client("192.168.1.100", use_async=True)
+client = Client("192.168.1.100")
 
 # Connect to the device:
 await client.connect()
 
 # Run various commands:
-# ...
+await client.device.ping()
+await client.device.diagnostics()
 
 # Disconnect from the device – notice that this is a regular method:
 client.disconnect()
@@ -55,7 +75,6 @@ client.disconnect()
 
 asyncio.run(main())
 ```
-
 ## Commands
 
 Many commands are available:

--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -42,6 +42,15 @@ class Client:
 
         self.device = Device(self.execute_command)
 
+    async def __aenter__(self):
+        """Define an entry point into this object via a context manager."""
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """Define an exit point out of this object via a context manager."""
+        self.disconnect()
+
     async def connect(self) -> None:
         """Connect to the Guardian device."""
         try:

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -12,32 +12,25 @@ async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.DEBUG)
 
-    guardian = Client("172.16.11.208")
+    async with Client("172.16.11.208") as guardian:
+        try:
+            # Run through various device-related commands:
+            ping_response = await guardian.device.ping()
+            _LOGGER.info("Ping response: %s", ping_response)
 
-    try:
-        # Connect to the device:
-        await guardian.connect()
+            diagnostics_response = await guardian.device.diagnostics()
+            _LOGGER.info("Diagnostics response: %s", diagnostics_response)
 
-        # Run through various device-related commands:
-        ping_response = await guardian.device.ping()
-        _LOGGER.info("Ping response: %s", ping_response)
+            reboot_response = await guardian.device.reboot()
+            _LOGGER.info("Reboot response: %s", reboot_response)
 
-        diagnostics_response = await guardian.device.diagnostics()
-        _LOGGER.info("Diagnostics response: %s", diagnostics_response)
+            # factory_reset_response = await guardian.device.factory_reset()
+            # _LOGGER.info("Factory reset response: %s", factory_reset_response)
 
-        reboot_response = await guardian.device.reboot()
-        _LOGGER.info("Reboot response: %s", reboot_response)
-
-        # factory_reset_response = await guardian.device.factory_reset()
-        # _LOGGER.info("Factory reset response: %s", factory_reset_response)
-
-        # upgrade_firmware_response = await guardian.device.upgrade_firmware()
-        # _LOGGER.info("Upgrade firmware response: %s", upgrade_firmware_response)
-
-        # Disconnect from the device:
-        guardian.disconnect()
-    except GuardianError as err:
-        _LOGGER.info(err)
+            # upgrade_firmware_response = await guardian.device.upgrade_firmware()
+            # _LOGGER.info("Upgrade firmware response: %s", upgrade_firmware_response)
+        except GuardianError as err:
+            _LOGGER.info(err)
 
 
 asyncio.run(main())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,29 +20,23 @@ async def test_command_without_socket_connect():
 @pytest.mark.asyncio
 async def test_connect_timeout():
     """Test that a timeout during connection throws an exception."""
-    client = Client("192.168.1.100")
-
     with patch(
         "asyncio_dgram.connect", CoroutineMock(side_effect=asyncio.TimeoutError)
     ):
         with pytest.raises(SocketError) as err:
-            await client.connect()
-            await client.device.ping()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                await client.device.ping()
             assert "Connection to device timed out" in err
 
 
 @pytest.mark.asyncio
 async def test_request_timeout():
     """Test that a timeout during connection throws an exception."""
-    client = Client("192.168.1.100")
-
     with patch(
         "asyncio_dgram.aio.DatagramStream.send",
         CoroutineMock(side_effect=asyncio.TimeoutError),
     ):
         with pytest.raises(SocketError) as err:
-            await client.connect()
-            await client.device.ping()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                await client.device.ping()
             assert "Request timed out" in err

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -14,11 +14,9 @@ from tests.common import load_fixture
 )
 async def test_diagnostics_success(mock_datagram_client):
     """Test successfully getting diagnostics info in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
-        await client.connect()
-        diagnostics_response = await client.device.diagnostics()
-        client.disconnect()
+        async with Client("192.168.1.100") as client:
+            diagnostics_response = await client.device.diagnostics()
         assert diagnostics_response["command"] == 1
         assert diagnostics_response["status"] == "ok"
         assert diagnostics_response["data"]["codename"] == "gvc1"
@@ -35,12 +33,10 @@ async def test_diagnostics_success(mock_datagram_client):
 )
 async def test_diagnostics_failure(mock_datagram_client):
     """Test the diagnostics command failing in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
         with pytest.raises(RequestError) as err:
-            await client.connect()
-            _ = await client.device.diagnostics()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.diagnostics()
             assert "error" in err
 
 
@@ -50,11 +46,9 @@ async def test_diagnostics_failure(mock_datagram_client):
 )
 async def test_factory_reset_success(mock_datagram_client):
     """Test successfully getting factory_reset info in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
-        await client.connect()
-        factory_reset_response = await client.device.factory_reset()
-        client.disconnect()
+        async with Client("192.168.1.100") as client:
+            factory_reset_response = await client.device.factory_reset()
         assert factory_reset_response["command"] == 255
         assert factory_reset_response["status"] == "ok"
 
@@ -65,12 +59,10 @@ async def test_factory_reset_success(mock_datagram_client):
 )
 async def test_factory_reset_failure(mock_datagram_client):
     """Test the factory_reset command failing in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
         with pytest.raises(RequestError) as err:
-            await client.connect()
-            _ = await client.device.factory_reset()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.factory_reset()
             assert "error" in err
 
 
@@ -81,11 +73,9 @@ async def test_factory_reset_failure(mock_datagram_client):
 )
 async def test_upgrade_firmware_success(mock_datagram_client):
     """Test successfully getting upgrade_firmware info in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
-        await client.connect()
-        upgrade_firmware_response = await client.device.upgrade_firmware()
-        client.disconnect()
+        async with Client("192.168.1.100") as client:
+            upgrade_firmware_response = await client.device.upgrade_firmware()
         assert upgrade_firmware_response["command"] == 4
         assert upgrade_firmware_response["status"] == "ok"
 
@@ -97,11 +87,10 @@ async def test_upgrade_firmware_success(mock_datagram_client):
 )
 async def test_upgrade_firmware_failure(mock_datagram_client):
     """Test the upgrade_firmware command failing in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
         with pytest.raises(RequestError) as err:
-            await client.connect()
-            _ = await client.device.upgrade_firmware()
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.upgrade_firmware()
             client.disconnect()
             assert "error" in err
 
@@ -112,11 +101,9 @@ async def test_upgrade_firmware_failure(mock_datagram_client):
 )
 async def test_ping_success(mock_datagram_client):
     """Test a successful ping of the device in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
-        await client.connect()
-        ping_response = await client.device.ping()
-        client.disconnect()
+        async with Client("192.168.1.100") as client:
+            ping_response = await client.device.ping()
         assert ping_response["command"] == 0
         assert ping_response["status"] == "ok"
         assert ping_response["data"]["uid"] == "ABCDEF123456"
@@ -128,12 +115,10 @@ async def test_ping_success(mock_datagram_client):
 )
 async def test_ping_failure(mock_datagram_client):
     """Test a failureful ping of the device in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
         with pytest.raises(RequestError) as err:
-            await client.connect()
-            _ = await client.device.ping()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.ping()
             assert "error" in err
 
 
@@ -143,11 +128,9 @@ async def test_ping_failure(mock_datagram_client):
 )
 async def test_reboot_success(mock_datagram_client):
     """Test successfully getting reboot info in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
-        await client.connect()
-        reboot_response = await client.device.reboot()
-        client.disconnect()
+        async with Client("192.168.1.100") as client:
+            reboot_response = await client.device.reboot()
         assert reboot_response["command"] == 2
         assert reboot_response["status"] == "ok"
 
@@ -158,10 +141,8 @@ async def test_reboot_success(mock_datagram_client):
 )
 async def test_reboot_failure(mock_datagram_client):
     """Test the reboot command failing in async mode."""
-    client = Client("192.168.1.100")
     with mock_datagram_client:
         with pytest.raises(RequestError) as err:
-            await client.connect()
-            _ = await client.device.reboot()
-            client.disconnect()
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.reboot()
             assert "error" in err


### PR DESCRIPTION
**Describe what the PR does:**

This PR creates an async context manager for `Client`, which allows users to focus on sending commands and let connection/disconnection be handled for them.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
