### PR TITLE
Fix incorrect async timeout in client connect

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -53,10 +53,11 @@ class Client:
 
     async def connect(self) -> None:
         """Connect to the Guardian device."""
-        try:
-            self._stream = await asyncio_dgram.connect((self._ip, self._port))
-        except asyncio.TimeoutError:
-            raise SocketError(f"Connection to device timed out")
+        async with timeout(DEFAULT_REQUEST_TIMEOUT):
+            try:
+                self._stream = await asyncio_dgram.connect((self._ip, self._port))
+            except asyncio.TimeoutError:
+                raise SocketError(f"Connection to device timed out")
 
     def disconnect(self) -> None:
         """Close the connection."""


### PR DESCRIPTION
**Describe what the PR does:**

We failed to properly implement timeout control when connecting via the `Client`. This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
