### PR TITLE
Create Command helper

### DIFF
--- a/aioguardian/device.py
+++ b/aioguardian/device.py
@@ -1,13 +1,15 @@
 """async define device info-related API endpoints."""
 from typing import Callable, Coroutine
 
+from aioguardian.helpers.command import Command
+
 DEFAULT_FIRMWARE_UPGRADE_FILENAME = "latest.bin"
 DEFAULT_FIRMWARE_UPGRADE_PORT = 443
 DEFAULT_FIRMWARE_UPGRADE_URL = "https://repo.guardiancloud.services/gvc/fw"
 
 
 class Device:
-    """async define the endpoint manager.
+    """Define the manager object.
 
     Note that this class shouldn't be instantiated directly; it will be instantiated as
     appropriate when creating a :meth:`aioguardian.client.Client`.
@@ -22,28 +24,28 @@ class Device:
 
         :rtype: ``dict``
         """
-        return await self._execute_command(1)
+        return await self._execute_command(Command.diagnostics)
 
     async def factory_reset(self) -> dict:
         """Perform a factory reset on the device.
 
         :rtype: ``dict``
         """
-        return await self._execute_command(255)
+        return await self._execute_command(Command.factory_reset)
 
     async def ping(self) -> dict:
         """Ping the device.
 
         :rtype: ``dict``
         """
-        return await self._execute_command(0)
+        return await self._execute_command(Command.ping)
 
     async def reboot(self) -> dict:
         """Reboot the device.
 
         :rtype: ``dict``
         """
-        return await self._execute_command(2)
+        return await self._execute_command(Command.reboot)
 
     async def upgrade_firmware(
         self,
@@ -63,5 +65,6 @@ class Device:
         :rtype: ``dict``
         """
         return await self._execute_command(
-            4, params={"url": url, "port": port, "filename": filename}
+            Command.upgrade_firmware,
+            params={"url": url, "port": port, "filename": filename},
         )

--- a/aioguardian/helpers/__init__.py
+++ b/aioguardian/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Define library helpers."""

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -1,0 +1,12 @@
+"""Define command helpers."""
+from enum import Enum
+
+
+class Command(Enum):
+    """Define a Guardian UDP command mapping."""
+
+    ping = 0
+    diagnostics = 1
+    reboot = 2
+    upgrade_firmware = 4
+    factory_reset = 255

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,8 @@ async def test_command_without_socket_connect():
     client = Client("192.168.1.100")
     with pytest.raises(SocketError) as err:
         await client.device.ping()
-        assert "You aren't connected to the device yet" in err
+
+    assert str(err.value) == "You aren't connected to the device yet"
 
 
 @pytest.mark.asyncio
@@ -26,7 +27,8 @@ async def test_connect_timeout():
         with pytest.raises(SocketError) as err:
             async with Client("192.168.1.100") as client:
                 await client.device.ping()
-            assert "Connection to device timed out" in err
+
+        assert str(err.value) == "Connection to device timed out"
 
 
 @pytest.mark.asyncio
@@ -39,4 +41,5 @@ async def test_request_timeout():
         with pytest.raises(SocketError) as err:
             async with Client("192.168.1.100") as client:
                 await client.device.ping()
-            assert "Request timed out" in err
+
+        assert str(err.value) == "ping command timed out"

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -37,7 +37,8 @@ async def test_diagnostics_failure(mock_datagram_client):
         with pytest.raises(RequestError) as err:
             async with Client("192.168.1.100") as client:
                 _ = await client.device.diagnostics()
-            assert "error" in err
+
+    assert "diagnostics command failed" in str(err.value)
 
 
 @pytest.mark.asyncio
@@ -63,7 +64,8 @@ async def test_factory_reset_failure(mock_datagram_client):
         with pytest.raises(RequestError) as err:
             async with Client("192.168.1.100") as client:
                 _ = await client.device.factory_reset()
-            assert "error" in err
+
+    assert "factory_reset command failed" in str(err.value)
 
 
 @pytest.mark.asyncio
@@ -92,7 +94,8 @@ async def test_upgrade_firmware_failure(mock_datagram_client):
             async with Client("192.168.1.100") as client:
                 _ = await client.device.upgrade_firmware()
             client.disconnect()
-            assert "error" in err
+
+    assert "upgrade_firmware command failed" in str(err.value)
 
 
 @pytest.mark.asyncio
@@ -119,7 +122,8 @@ async def test_ping_failure(mock_datagram_client):
         with pytest.raises(RequestError) as err:
             async with Client("192.168.1.100") as client:
                 _ = await client.device.ping()
-            assert "error" in err
+
+    assert "ping command failed" in str(err.value)
 
 
 @pytest.mark.asyncio
@@ -145,4 +149,5 @@ async def test_reboot_failure(mock_datagram_client):
         with pytest.raises(RequestError) as err:
             async with Client("192.168.1.100") as client:
                 _ = await client.device.reboot()
-            assert "error" in err
+
+    assert "reboot command failed" in str(err.value)


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the concept of a `Command` class (via a helper) that associates a friendly command name with the integer that the Guardian API specifies. This does two things:

1. Abstracts the connection between command and integer such that sub-classes (like `device`) don't need to know about the integers
2. Makes it possible to provide better logging when a command fails

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioguardian/issues/<ISSUE ID>
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
