### PR TITLE
Remove event loop attribute in Client

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -25,20 +25,11 @@ class Client:
     :type ip_address: ``str``
     :param port: The port to connect to
     :type port: ``int``
-    :param event_loop: An  ``asyncio`` event loop to attach this Client to
-    :type event_loop: ``asyncio.AbstractEventLoop``
     """
 
-    def __init__(
-        self,
-        ip_address: str,
-        *,
-        port: int = DEFAULT_PORT,
-        event_loop: Optional[asyncio.AbstractEventLoop] = None,
-    ) -> None:
+    def __init__(self, ip_address: str, *, port: int = DEFAULT_PORT,) -> None:
         """Initialize."""
         self._ip: str = ip_address
-        self._loop: Optional[asyncio.AbstractEventLoop] = event_loop
         self._port: int = port
         self._stream: asyncio_dgram.aio.DatagramStream = None
 

--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -27,7 +27,7 @@ class Client:
     :type port: ``int``
     """
 
-    def __init__(self, ip_address: str, *, port: int = DEFAULT_PORT,) -> None:
+    def __init__(self, ip_address: str, *, port: int = DEFAULT_PORT) -> None:
         """Initialize."""
         self._ip: str = ip_address
         self._port: int = port


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes the `event_loop` parameter when creating a `Client` because it was a vestige of [our previous sync/async experiment](https://github.com/bachya/aioguardian/pull/9) and is no longer needed.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
