### PR TITLE
Create a more friendly representation of the valve status

### DIFF
--- a/aioguardian/__init__.py
+++ b/aioguardian/__init__.py
@@ -1,2 +1,3 @@
 """Define the aioguardian package."""
-from .client import Client  # noqa
+from aioguardian.client import Client  # noqa
+from aioguardian.commands.valve import ValveState  # noqa

--- a/aioguardian/commands/valve.py
+++ b/aioguardian/commands/valve.py
@@ -1,7 +1,26 @@
 """async define onboard valve-related API endpoints."""
+from enum import Enum
 from typing import Callable, Coroutine
 
 from aioguardian.helpers.command import Command
+
+
+class ValveState(Enum):
+    """Define a representation of the valve's state."""
+
+    default = 0
+    start_opening = 1
+    opening = 2
+    finish_opening = 3
+    opened = 4
+    start_closing = 5
+    closing = 6
+    finish_closing = 7
+    closed = 8
+    start_halt = 9
+    stalled = 10
+    free_spin = 11
+    halted = 12
 
 
 class Valve:  # pylint: disable=too-few-public-methods
@@ -20,4 +39,6 @@ class Valve:  # pylint: disable=too-few-public-methods
 
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.valve_status)
+        data = await self._execute_command(Command.valve_status)
+        data["data"]["state"] = ValveState(data["data"]["state"])
+        return data

--- a/tests/test_valve_commands.py
+++ b/tests/test_valve_commands.py
@@ -1,7 +1,7 @@
 """Test commands related to the device's valve."""
 import pytest
 
-from aioguardian import Client
+from aioguardian import Client, ValveState
 from aioguardian.errors import RequestError
 
 from tests.common import load_fixture
@@ -20,7 +20,7 @@ async def test_valve_status_success(mock_datagram_client):
         assert valve_status_response["status"] == "ok"
         valve_status_response["data"]["enabled"] = False
         valve_status_response["data"]["direction"] = True
-        valve_status_response["data"]["state"] = 0
+        valve_status_response["data"]["state"] = ValveState.default
         valve_status_response["data"]["travel_count"] = 0
         valve_status_response["data"]["instantaneous_current"] = 0
         valve_status_response["data"]["instantaneous_current_ddt"] = 0


### PR DESCRIPTION
**Describe what the PR does:**

Previously, `client.valve.valve_status` would return an integer for the valve's state. According to the API docs, there are 13 different states; this PR creates a more human-friendly representation that doesn't rely on people knowing what the integers mean.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
