### PR TITLE
Change valve state representation to constants (instead of Enum)

### DIFF
--- a/aioguardian/__init__.py
+++ b/aioguardian/__init__.py
@@ -1,3 +1,2 @@
 """Define the aioguardian package."""
 from aioguardian.client import Client  # noqa
-from aioguardian.commands.valve import ValveState  # noqa

--- a/aioguardian/commands/valve.py
+++ b/aioguardian/commands/valve.py
@@ -1,26 +1,23 @@
 """async define onboard valve-related API endpoints."""
-from enum import Enum
 from typing import Callable, Coroutine
 
 from aioguardian.helpers.command import Command
 
-
-class ValveState(Enum):
-    """Define a representation of the valve's state."""
-
-    default = 0
-    start_opening = 1
-    opening = 2
-    finish_opening = 3
-    opened = 4
-    start_closing = 5
-    closing = 6
-    finish_closing = 7
-    closed = 8
-    start_halt = 9
-    stalled = 10
-    free_spin = 11
-    halted = 12
+VALVE_STATE_MAPPING = {
+    0: "default",
+    1: "start_opening",
+    2: "opening",
+    3: "finish_opening",
+    4: "opened",
+    5: "start_closing",
+    6: "closing",
+    7: "finish_closing",
+    8: "closed",
+    9: "start_halt",
+    10: "stalled",
+    11: "free_spin",
+    12: "halted",
+}
 
 
 class Valve:  # pylint: disable=too-few-public-methods
@@ -40,5 +37,5 @@ class Valve:  # pylint: disable=too-few-public-methods
         :rtype: ``dict``
         """
         data = await self._execute_command(Command.valve_status)
-        data["data"]["state"] = ValveState(data["data"]["state"])
+        data["data"]["state"] = VALVE_STATE_MAPPING[data["data"]["state"]]
         return data

--- a/tests/test_valve_commands.py
+++ b/tests/test_valve_commands.py
@@ -1,7 +1,7 @@
 """Test commands related to the device's valve."""
 import pytest
 
-from aioguardian import Client, ValveState
+from aioguardian import Client
 from aioguardian.errors import RequestError
 
 from tests.common import load_fixture
@@ -20,7 +20,7 @@ async def test_valve_status_success(mock_datagram_client):
         assert valve_status_response["status"] == "ok"
         valve_status_response["data"]["enabled"] = False
         valve_status_response["data"]["direction"] = True
-        valve_status_response["data"]["state"] = ValveState.default
+        valve_status_response["data"]["state"] = "default"
         valve_status_response["data"]["travel_count"] = 0
         valve_status_response["data"]["instantaneous_current"] = 0
         valve_status_response["data"]["instantaneous_current_ddt"] = 0


### PR DESCRIPTION
**Describe what the PR does:**

#17 used an `Enum` to represent the valve state, but in practice, that seems like too much overhead (especially since it would force users to import that `Enum` to compare values). This PR transitions the state representation to a set of string constants.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
