### PR TITLE
Sleep for 3 seconds after issuing a reboot command

### DIFF
--- a/aioguardian/commands/device.py
+++ b/aioguardian/commands/device.py
@@ -1,4 +1,5 @@
 """async define device info-related API endpoints."""
+import asyncio
 from typing import Callable, Coroutine
 
 from aioguardian.helpers.command import Command
@@ -45,7 +46,15 @@ class Device:
 
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.reboot)
+        resp = await self._execute_command(Command.reboot)
+
+        # The Guardian API docs indicate that the reboot will occur "3 seconds after
+        # command is received" – in order to guard against errors from subsequent
+        # commands while the reboot is occurring, we sleep for 3 seconds before
+        # returning the response:
+        await asyncio.sleep(3)
+
+        return resp
 
     async def upgrade_firmware(
         self,

--- a/tests/test_device_commands.py
+++ b/tests/test_device_commands.py
@@ -1,4 +1,5 @@
 """Test commands related to the device itself."""
+from asynctest import CoroutineMock, patch
 import pytest
 
 from aioguardian import Client
@@ -141,7 +142,9 @@ async def test_reboot_success(mock_datagram_client):
     """Test the reboot command succeeding."""
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
-            reboot_response = await client.device.reboot()
+            # Patch asyncio.sleep so that this test doesn't take 3-ish seconds:
+            with patch("asyncio.sleep", CoroutineMock()):
+                reboot_response = await client.device.reboot()
         assert reboot_response["command"] == 2
         assert reboot_response["status"] == "ok"
 


### PR DESCRIPTION
**Describe what the PR does:**

The Guardian API docs make this statement about the reboot command:

>The restart will occur 3 seconds after command is received.

In order to guard against possible errors from subsequent commands while the reboot is occurring, this PR adds a 3-second sleep to account for this.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
