### PR TITLE
Add support for the wife_enable_ap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Many commands are available:
 * `client.device.reboot()`: reboot the device
 * `client.device.upgrade_firmware()`: initiate a firmware upgrade on the device
 * `client.device.wifi_configure()`: connect the device to an SSID
+* `client.device.wifi_enable_ap()`: enable the device's onboard WiFi access point
 * `client.device.wifi_reset()`: reset all WiFi info
 * `client.device.wifi_status()`: get information related to the device's WiFi connections
 * `client.sensor.sensor_status()`: get information from the device's onboard sensors

--- a/aioguardian/commands/device.py
+++ b/aioguardian/commands/device.py
@@ -124,6 +124,13 @@ class Device:
 
         return await self._execute_command(Command.wifi_configure, params=params)
 
+    async def wifi_enable_ap(self) -> dict:
+        """Enable the device's onboard WiFi access point.
+
+        :rtype: ``dict``
+        """
+        return await self._execute_command(Command.wifi_enable_ap)
+
     async def wifi_reset(self) -> dict:
         """Erase and reset all WiFi settings.
 

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -17,5 +17,6 @@ class Command(Enum):
     wifi_status = 32
     wifi_reset = 33
     wifi_configure = 34
+    wifi_enable_ap = 35
     sensor_status = 80
     factory_reset = 255

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -47,6 +47,11 @@ async def main() -> None:
             #     "wifi_configure command response: %s", wifi_configure_response
             # )
 
+            # wifi_enable_ap_response = await guardian.device.wifi_enable_ap()
+            # _LOGGER.info(
+            #     "wifi_enable_ap command response: %s", wifi_enable_ap_response
+            # )
+
             # --- SENSOR COMMANDS ---
             sensor_status_response = await guardian.sensor.sensor_status()
             _LOGGER.info(

--- a/tests/fixtures/wifi_enable_ap_failure_response.json
+++ b/tests/fixtures/wifi_enable_ap_failure_response.json
@@ -1,0 +1,4 @@
+{
+  "command": 35,
+  "status": "error"
+}

--- a/tests/fixtures/wifi_enable_ap_success_response.json
+++ b/tests/fixtures/wifi_enable_ap_success_response.json
@@ -1,0 +1,4 @@
+{
+  "command": 35,
+  "status": "ok"
+}

--- a/tests/test_device/test_wifi_enable_ap.py
+++ b/tests/test_device/test_wifi_enable_ap.py
@@ -1,0 +1,36 @@
+"""Test the wifi_enable_ap command."""
+import pytest
+
+from aioguardian import Client
+from aioguardian.errors import CommandError
+
+from tests.common import load_fixture
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("wifi_enable_ap_failure_response.json").encode()]
+)
+async def test_wifi_enable_ap_failure(mock_datagram_client):
+    """Test the wifi_enable_ap command failing."""
+    with mock_datagram_client:
+        with pytest.raises(CommandError) as err:
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.wifi_enable_ap()
+
+    assert str(err.value) == (
+        "wifi_enable_ap command failed (response: {'command': 35, 'status': 'error'})"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("wifi_enable_ap_success_response.json").encode()]
+)
+async def test_wifi_enable_ap_success(mock_datagram_client):
+    """Test the wifi_enable_ap command succeeding."""
+    with mock_datagram_client:
+        async with Client("192.168.1.100") as client:
+            wifi_enable_ap_response = await client.device.wifi_enable_ap()
+        assert wifi_enable_ap_response["command"] == 35
+        assert wifi_enable_ap_response["status"] == "ok"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for enabling the device's onboard WiFi access point.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
