### PR TITLE
Add support for the pair_dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Many commands are available:
 * `client.device.wifi_enable_ap()`: enable the device's onboard WiFi access point
 * `client.device.wifi_reset()`: reset all WiFi info
 * `client.device.wifi_status()`: get information related to the device's WiFi connections
+* `client.sensor.pair_dump()`: get information on all paired sensors
 * `client.sensor.sensor_status()`: get information from the device's onboard sensors
 * `client.valve.valve_close()`: close the valve
 * `client.valve.valve_halt()`: halt the valve mid-open or mid-close (be careful!)

--- a/aioguardian/commands/sensor.py
+++ b/aioguardian/commands/sensor.py
@@ -15,6 +15,13 @@ class Sensor:  # pylint: disable=too-few-public-methods
         """Initialize."""
         self._execute_command: Callable[..., Coroutine] = execute_command
 
+    async def pair_dump(self) -> dict:
+        """Dump information on all paired sensors.
+
+        :rtype: ``dict``
+        """
+        return await self._execute_command(Command.pair_dump)
+
     async def sensor_status(self) -> dict:
         """Retrieve status of onboard sensors (not external, paired sensors).
 

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -19,5 +19,6 @@ class Command(Enum):
     wifi_configure = 34
     wifi_enable_ap = 35
     wifi_disable_ap = 36
+    pair_dump = 48
     sensor_status = 80
     factory_reset = 255

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -63,6 +63,12 @@ async def main() -> None:
                 "sensor_status_response command response: %s", sensor_status_response
             )
 
+            sensor_pair_dump_response = await guardian.sensor.sensor_pair_dump()
+            _LOGGER.info(
+                "sensor_pair_dump_response command response: %s",
+                sensor_pair_dump_response,
+            )
+
             # --- VALVE COMMANDS ---
             valve_status_response = await guardian.valve.valve_status()
             _LOGGER.info(

--- a/tests/fixtures/pair_dump_failure_response.json
+++ b/tests/fixtures/pair_dump_failure_response.json
@@ -1,0 +1,4 @@
+{
+  "command": 48,
+  "status": "error"
+}

--- a/tests/fixtures/pair_dump_success_response.json
+++ b/tests/fixtures/pair_dump_success_response.json
@@ -1,0 +1,8 @@
+{
+  "command": 48,
+  "status": "ok",
+  "data": {
+    "pair_count": 0,
+    "paired_uids": []
+  }
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ async def test_connect_timeout():
 
 @pytest.mark.asyncio
 async def test_request_timeout():
-    """Test that a timeout during connection throws an exception."""
+    """Test that a timeout during command execution throws an exception."""
     with patch(
         "asyncio_dgram.aio.DatagramStream.send",
         CoroutineMock(side_effect=asyncio.TimeoutError),

--- a/tests/test_sensor/test_pair_dump.py
+++ b/tests/test_sensor/test_pair_dump.py
@@ -1,0 +1,36 @@
+"""Test the sensor_status command."""
+import pytest
+
+from aioguardian import Client
+from aioguardian.errors import CommandError
+
+from tests.common import load_fixture
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("pair_dump_success_response.json").encode()]
+)
+async def test_pair_dump_success(mock_datagram_client):
+    """Test the pair_dump command succeeding."""
+    with mock_datagram_client:
+        async with Client("192.168.1.100") as client:
+            pair_dump_response = await client.sensor.pair_dump()
+        assert pair_dump_response["command"] == 48
+        assert pair_dump_response["status"] == "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("pair_dump_failure_response.json").encode()]
+)
+async def test_pair_dump_failure(mock_datagram_client):
+    """Test the pair_dump command failing."""
+    with mock_datagram_client:
+        with pytest.raises(CommandError) as err:
+            async with Client("192.168.1.100") as client:
+                _ = await client.sensor.pair_dump()
+
+    assert str(err.value) == (
+        "pair_dump command failed (response: {'command': 48, 'status': 'error'})"
+    )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for the dumping info on all sensors paired to the device.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
