### PR TITLE
Add support for the publish_state command

### DIFF
--- a/aioguardian/commands/device.py
+++ b/aioguardian/commands/device.py
@@ -66,6 +66,13 @@ class Device:
         """
         return await self._execute_command(Command.ping)
 
+    async def publish_state(self) -> dict:
+        """Publish the device's complete state to the Guardian cloud.
+
+        :rtype: ``dict``
+        """
+        return await self._execute_command(Command.publish_state)
+
     async def reboot(self) -> dict:
         """Reboot the device.
 

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -21,5 +21,6 @@ class Command(Enum):
     wifi_disable_ap = 36
     pair_dump = 48
     pair_sensor = 49
+    publish_state = 65
     sensor_status = 80
     factory_reset = 255

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -18,6 +18,9 @@ async def main() -> None:
             ping_response = await guardian.device.ping()
             _LOGGER.info("ping command response: %s", ping_response)
 
+            # publish_state_response = await guardian.device.publish_state()
+            # _LOGGER.info("publish_state command response: %s", publish_state_response)
+
             diagnostics_response = await guardian.device.diagnostics()
             _LOGGER.info("diagnostics command response: %s", diagnostics_response)
 
@@ -36,21 +39,15 @@ async def main() -> None:
             _LOGGER.info("wifi_status command response: %s", wifi_status_response)
 
             # wifi_reset_response = await guardian.device.wifi_reset()
-            # _LOGGER.info(
-            #     "wifi_reset command response: %s", wifi_reset_response
-            # )
+            # _LOGGER.info("wifi_reset command response: %s", wifi_reset_response)
 
             # wifi_configure_response = await guardian.device.wifi_configure(
             #     "<SSID>", "<PASSWORD>"
             # )
-            # _LOGGER.info(
-            #     "wifi_configure command response: %s", wifi_configure_response
-            # )
+            # _LOGGER.info("wifi_configure command response: %s", wifi_configure_response)
 
             # wifi_enable_ap_response = await guardian.device.wifi_enable_ap()
-            # _LOGGER.info(
-            #     "wifi_enable_ap command response: %s", wifi_enable_ap_response
-            # )
+            # _LOGGER.info("wifi_enable_ap command response: %s", wifi_enable_ap_response)
 
             # wifi_disable_ap_response = await guardian.device.wifi_disable_ap()
             # _LOGGER.info(

--- a/tests/fixtures/publish_state_failure_response.json
+++ b/tests/fixtures/publish_state_failure_response.json
@@ -1,0 +1,4 @@
+{
+  "command": 65,
+  "status": "error"
+}

--- a/tests/fixtures/publish_state_success_response.json
+++ b/tests/fixtures/publish_state_success_response.json
@@ -1,0 +1,4 @@
+{
+  "command": 65,
+  "status": "ok"
+}

--- a/tests/test_device/test_publish_state.py
+++ b/tests/test_device/test_publish_state.py
@@ -1,0 +1,37 @@
+"""Test the publish_state command."""
+import pytest
+
+from aioguardian import Client
+from aioguardian.errors import CommandError
+
+from tests.common import load_fixture
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("publish_state_failure_response.json").encode()],
+)
+async def test_publish_state_failure(mock_datagram_client):
+    """Test the publish_state command failing."""
+    with mock_datagram_client:
+        with pytest.raises(CommandError) as err:
+            async with Client("192.168.1.100") as client:
+                _ = await client.device.publish_state()
+            client.disconnect()
+
+    assert str(err.value) == (
+        "publish_state command failed (response: {'command': 65, 'status': 'error'})"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("publish_state_success_response.json").encode()],
+)
+async def test_publish_state_success(mock_datagram_client):
+    """Test the publish_state command succeeding."""
+    with mock_datagram_client:
+        async with Client("192.168.1.100") as client:
+            publish_state_response = await client.device.publish_state()
+        assert publish_state_response["command"] == 65
+        assert publish_state_response["status"] == "ok"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for publishing the device's current state to the Guardian cloud.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
