### PR TITLE
Raise when response doesn't match command

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -91,6 +91,12 @@ class Client:
         decoded_data = json.loads(data.decode())
         _LOGGER.debug("Received data from %s: %s", remote_addr, decoded_data)
 
+        if decoded_data["command"] != command.value:
+            raise CommandError(
+                f"Sent command {command.value}, but got response for "
+                f"command {decoded_data['command']}"
+            )
+
         _raise_on_command_error(command, decoded_data)
 
         return decoded_data

--- a/aioguardian/commands/valve.py
+++ b/aioguardian/commands/valve.py
@@ -102,8 +102,5 @@ class Valve:
         :rtype: ``dict``
         """
         resp = await self._execute_command(Command.valve_status, silent=silent)
-        try:
-            resp["data"]["state"] = VALVE_STATE_MAPPING[resp["data"]["state"]]
-        except KeyError:
-            _LOGGER.error(resp)
+        resp["data"]["state"] = VALVE_STATE_MAPPING[resp["data"]["state"]]
         return resp

--- a/aioguardian/commands/valve.py
+++ b/aioguardian/commands/valve.py
@@ -102,5 +102,8 @@ class Valve:
         :rtype: ``dict``
         """
         resp = await self._execute_command(Command.valve_status, silent=silent)
-        resp["data"]["state"] = VALVE_STATE_MAPPING[resp["data"]["state"]]
+        try:
+            resp["data"]["state"] = VALVE_STATE_MAPPING[resp["data"]["state"]]
+        except KeyError:
+            _LOGGER.error(resp)
         return resp

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,3 +85,17 @@ async def test_unknown_raw_command(mock_datagram_client):
                 await client.execute_raw_command(999)
 
         assert str(err.value) == "Unknown command code: 999"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_response", [load_fixture("ping_success_response.json").encode()]
+)
+async def test_wrong_response(mock_datagram_client):
+    """Test the case when the device returns a response other than the command."""
+    with mock_datagram_client:
+        with pytest.raises(CommandError) as err:
+            async with Client("192.168.1.100") as client:
+                await client.device.wifi_status()
+
+        assert str(err.value) == "Sent command 32, but got response for command 0"


### PR DESCRIPTION
**Describe what the PR does:**

At very sporadic times, the device returns the response for a different command than what was requested; this appears to be a bug in the device. `aioguardian` can't fix the issue, per se, so this PR raises a `CommandError` when this situation arises.

**Does this fix a specific issue?**

Guards against https://github.com/bachya/aioguardian/issues/40, but doesn't fix it; waiting to see if Elexa fixes the bug.
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
