### PR TITLE
Fix bug with incorrect async_timeout usage

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -112,12 +112,12 @@ class Client:
         _params = params or {}
         payload = {"command": command.value, "silent": silent, **_params}
 
-        async with timeout(self._request_timeout):
-            try:
+        try:
+            async with timeout(self._request_timeout):
                 await self._stream.send(json.dumps(payload).encode())
                 data, remote_addr = await self._stream.recv()
-            except asyncio.TimeoutError:
-                raise SocketError(f"{command.name} command timed out")
+        except asyncio.TimeoutError:
+            raise SocketError(f"{command.name} command timed out")
 
         decoded_data = json.loads(data.decode())
         _LOGGER.debug("Received data from %s: %s", remote_addr, decoded_data)
@@ -128,11 +128,11 @@ class Client:
 
     async def connect(self) -> None:
         """Connect to the Guardian device."""
-        async with timeout(self._request_timeout):
-            try:
+        try:
+            async with timeout(self._request_timeout):
                 self._stream = await asyncio_dgram.connect((self._ip, self._port))
-            except asyncio.TimeoutError:
-                raise SocketError(f"Connection to device timed out")
+        except asyncio.TimeoutError:
+            raise SocketError(f"Connection to device timed out")
 
     def disconnect(self) -> None:
         """Close the connection."""


### PR DESCRIPTION
**Describe what the PR does:**

I wasn't using `async_timeout` correctly, which led to unhandled exceptions in actual timeouts. This PR fixes that.

**Does this fix a specific issue?**

Discovered via #40.
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
