### PR TITLE
Add a locking mutex to command execution

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,20 +60,3 @@ async def test_request_timeout():
                 await client.device.ping()
 
         assert str(err.value) == "ping command timed out"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "command_response", [load_fixture("ping_success_response.json").encode()]
-)
-async def test_wrong_response(mock_datagram_client):
-    """Test the case when the device returns a response other than the command."""
-    with mock_datagram_client:
-        with pytest.raises(CommandError) as err:
-            async with Client("192.168.1.100") as client:
-                await client.device.wifi_status()
-
-        assert (
-            str(err.value)
-            == "Sent wifi_status command, but got response for ping command"
-        )


### PR DESCRIPTION
**Describe what the PR does:**

According to the Elexa engineer I've been working with, #40 can happen because the device is only using a single UDP socket – there will be times where a device timeout happens and gums up the works for other commands. This PR is part of a solution for #40: it adds a locking mutex to command execution to ensure there's no concurrency.

**Does this fix a specific issue?**

Related to #40 
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
