### PR TITLE
Move command error helper to correct module

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -11,7 +11,7 @@ import asyncio_dgram
 from aioguardian.commands.device import Device
 from aioguardian.commands.sensor import Sensor
 from aioguardian.commands.valve import Valve
-from aioguardian.errors import ERROR_CODE_MAPPING, CommandError, SocketError
+from aioguardian.errors import SocketError, _raise_on_command_error
 from aioguardian.helpers.command import Command, get_command_from_code
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,27 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_COMMAND_RETRIES: int = 3
 DEFAULT_PORT: int = 7777
 DEFAULT_REQUEST_TIMEOUT: int = 10
-
-
-def _raise_on_command_error(command: Command, data: dict) -> None:
-    """Examine a data response and raise errors appropriately.
-
-    :param command: The command that was run
-    :type command: :meth:`aioguardian.helpers.command.Command`
-    :param data: The response data from running the command
-    :type params: ``dict``
-    """
-    if data.get("status") == "ok":
-        return
-
-    # If we know exactly why the command failed, raise that error:
-    if data.get("error_code") in ERROR_CODE_MAPPING:
-        raise CommandError(
-            f"{command.name} command failed: {ERROR_CODE_MAPPING[data['error_code']]}"
-        )
-
-    # Last resort, return a generic error with the response payload:
-    raise CommandError(f"{command.name} command failed (response: {data})")
 
 
 class Client:  # pylint: disable=too-many-instance-attributes

--- a/aioguardian/errors.py
+++ b/aioguardian/errors.py
@@ -1,5 +1,8 @@
 """Define exception types for ``aioguardian``."""
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from aioguardian.helpers.command import Command
 
 ERROR_CODE_MAPPING: Dict[int, str] = {
     17: "valve_already_opened",
@@ -25,3 +28,24 @@ class SocketError(GuardianError):
     """Define an error related to UDP socket issues."""
 
     pass
+
+
+def _raise_on_command_error(command: "Command", data: dict) -> None:
+    """Examine a data response and raise errors appropriately.
+
+    :param command: The command that was run
+    :type command: :meth:`aioguardian.helpers.command.Command`
+    :param data: The response data from running the command
+    :type params: ``dict``
+    """
+    if data.get("status") == "ok":
+        return
+
+    # If we know exactly why the command failed, raise that error:
+    if data.get("error_code") in ERROR_CODE_MAPPING:
+        raise CommandError(
+            f"{command.name} command failed: {ERROR_CODE_MAPPING[data['error_code']]}"
+        )
+
+    # Last resort, return a generic error with the response payload:
+    raise CommandError(f"{command.name} command failed (response: {data})")


### PR DESCRIPTION
**Describe what the PR does:**

This PR moves `_raise_on_command_error` out of `aioguardian.client` and into `aioguardian.errors`, which makes more sense.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
