### PR TITLE
Adjust internal command names to match groupings and API

### DIFF
--- a/aioguardian/commands/iot.py
+++ b/aioguardian/commands/iot.py
@@ -23,4 +23,4 @@ class IOTCommands:  # pylint: disable=too-few-public-methods
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.publish_state, silent=silent)
+        return await self._execute_command(Command.iot_publish_state, silent=silent)

--- a/aioguardian/commands/sensor.py
+++ b/aioguardian/commands/sensor.py
@@ -33,7 +33,7 @@ class SensorCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.pair_dump, silent=silent)
+        return await self._execute_command(Command.sensor_pair_dump, silent=silent)
 
     async def pair_sensor(self, uid: str, *, silent: bool = True) -> dict:
         """Pair a new sensor to the device.
@@ -52,7 +52,7 @@ class SensorCommands:
             raise CommandError(f"Invalid parameters provided: {err}") from None
 
         return await self._execute_command(
-            Command.pair_sensor, params=params, silent=silent
+            Command.sensor_pair_sensor, params=params, silent=silent
         )
 
     async def unpair_sensor(self, uid: str, *, silent: bool = True) -> dict:
@@ -72,5 +72,5 @@ class SensorCommands:
             raise CommandError(f"Invalid parameters provided: {err}") from None
 
         return await self._execute_command(
-            Command.unpair_sensor, params=params, silent=silent
+            Command.sensor_unpair_sensor, params=params, silent=silent
         )

--- a/aioguardian/commands/system.py
+++ b/aioguardian/commands/system.py
@@ -44,7 +44,7 @@ class SystemCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.diagnostics, silent=silent)
+        return await self._execute_command(Command.system_diagnostics, silent=silent)
 
     async def factory_reset(self, *, silent: bool = True) -> dict:
         """Perform a factory reset on the device.
@@ -53,7 +53,7 @@ class SystemCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.factory_reset, silent=silent)
+        return await self._execute_command(Command.system_factory_reset, silent=silent)
 
     async def onboard_sensor_status(self, *, silent: bool = True) -> dict:
         """Retrieve status of the valve controller's onboard sensors.
@@ -62,7 +62,9 @@ class SystemCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.onboard_sensor_status, silent=silent)
+        return await self._execute_command(
+            Command.system_onboard_sensor_status, silent=silent
+        )
 
     async def ping(self, *, silent: bool = True) -> dict:
         """Ping the device.
@@ -71,7 +73,7 @@ class SystemCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        return await self._execute_command(Command.ping, silent=silent)
+        return await self._execute_command(Command.system_ping, silent=silent)
 
     async def reboot(self, *, silent: bool = True) -> dict:
         """Reboot the device.
@@ -80,7 +82,7 @@ class SystemCommands:
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        resp = await self._execute_command(Command.reboot, silent=silent)
+        resp = await self._execute_command(Command.system_reboot, silent=silent)
 
         # The Guardian API docs indicate that the reboot will occur "3 seconds after
         # command is received" – in order to guard against errors from subsequent
@@ -118,5 +120,5 @@ class SystemCommands:
             raise CommandError(f"Invalid parameters provided: {err}") from None
 
         return await self._execute_command(
-            Command.upgrade_firmware, params=params, silent=silent
+            Command.system_upgrade_firmware, params=params, silent=silent
         )

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -7,26 +7,26 @@ from aioguardian.errors import CommandError
 class Command(Enum):
     """Define a Guardian UDP command mapping."""
 
-    ping = 0
-    diagnostics = 1
-    reboot = 2
-    upgrade_firmware = 4
-    valve_status = 16
-    valve_open = 17
+    iot_publish_state = 65
+    sensor_pair_dump = 48
+    sensor_pair_sensor = 49
+    sensor_unpair_sensor = 50
+    system_diagnostics = 1
+    system_factory_reset = 255
+    system_onboard_sensor_status = 80
+    system_ping = 0
+    system_reboot = 2
+    system_upgrade_firmware = 4
     valve_close = 18
     valve_halt = 19
+    valve_open = 17
     valve_reset = 20
-    wifi_status = 32
-    wifi_reset = 33
+    valve_status = 16
     wifi_configure = 34
-    wifi_enable_ap = 35
     wifi_disable_ap = 36
-    pair_dump = 48
-    pair_sensor = 49
-    unpair_sensor = 50
-    publish_state = 65
-    onboard_sensor_status = 80
-    factory_reset = 255
+    wifi_enable_ap = 35
+    wifi_reset = 33
+    wifi_status = 32
 
 
 def get_command_from_name(command_name: str) -> Command:

--- a/tests/commands/iot/test_publish_state.py
+++ b/tests/commands/iot/test_publish_state.py
@@ -20,7 +20,8 @@ async def test_publish_state_failure(mock_datagram_client):
             client.disconnect()
 
     assert str(err.value) == (
-        "publish_state command failed (response: {'command': 65, 'status': 'error'})"
+        "iot_publish_state command failed "
+        "(response: {'command': 65, 'status': 'error'})"
     )
 
 

--- a/tests/commands/sensor/test_pair_dump.py
+++ b/tests/commands/sensor/test_pair_dump.py
@@ -19,7 +19,7 @@ async def test_pair_dump_failure(mock_datagram_client):
                 _ = await client.sensor.pair_dump()
 
     assert str(err.value) == (
-        "pair_dump command failed (response: {'command': 48, 'status': 'error'})"
+        "sensor_pair_dump command failed (response: {'command': 48, 'status': 'error'})"
     )
 
 

--- a/tests/commands/sensor/test_pair_sensor.py
+++ b/tests/commands/sensor/test_pair_sensor.py
@@ -19,7 +19,8 @@ async def test_pair_sensor_failure(mock_datagram_client):
                 _ = await client.sensor.pair_sensor("abc123")
 
     assert str(err.value) == (
-        "pair_sensor command failed (response: {'command': 49, 'status': 'error'})"
+        "sensor_pair_sensor command failed "
+        "(response: {'command': 49, 'status': 'error'})"
     )
 
 

--- a/tests/commands/sensor/test_unpair_sensor.py
+++ b/tests/commands/sensor/test_unpair_sensor.py
@@ -19,7 +19,8 @@ async def test_unpair_sensor_failure(mock_datagram_client):
                 _ = await client.sensor.unpair_sensor("abc123")
 
     assert str(err.value) == (
-        "unpair_sensor command failed (response: {'command': 50, 'status': 'error'})"
+        "sensor_unpair_sensor command failed "
+        "(response: {'command': 50, 'status': 'error'})"
     )
 
 

--- a/tests/commands/system/test_diagnostics.py
+++ b/tests/commands/system/test_diagnostics.py
@@ -19,7 +19,8 @@ async def test_diagnostics_failure(mock_datagram_client):
                 _ = await client.system.diagnostics()
 
     assert str(err.value) == (
-        "diagnostics command failed (response: {'command': 1, 'status': 'error'})"
+        "system_diagnostics command failed "
+        "(response: {'command': 1, 'status': 'error'})"
     )
 
 

--- a/tests/commands/system/test_factory_reset.py
+++ b/tests/commands/system/test_factory_reset.py
@@ -19,7 +19,8 @@ async def test_factory_reset_failure(mock_datagram_client):
                 _ = await client.system.factory_reset()
 
     assert str(err.value) == (
-        "factory_reset command failed (response: {'command': 255, 'status': 'error'})"
+        "system_factory_reset command failed "
+        "(response: {'command': 255, 'status': 'error'})"
     )
 
 

--- a/tests/commands/system/test_onboard_sensor_status.py
+++ b/tests/commands/system/test_onboard_sensor_status.py
@@ -37,5 +37,6 @@ async def test_onboard_sensor_status_failure(mock_datagram_client):
                 _ = await client.system.onboard_sensor_status()
 
     assert str(err.value) == (
-        "onboard_sensor_status command failed (response: {'command': 80, 'status': 'error'})"
+        "system_onboard_sensor_status command failed "
+        "(response: {'command': 80, 'status': 'error'})"
     )

--- a/tests/commands/system/test_ping.py
+++ b/tests/commands/system/test_ping.py
@@ -19,7 +19,7 @@ async def test_ping_failure(mock_datagram_client):
                 _ = await client.system.ping()
 
     assert str(err.value) == (
-        "ping command failed (response: {'command': 0, 'status': 'error'})"
+        "system_ping command failed (response: {'command': 0, 'status': 'error'})"
     )
 
 

--- a/tests/commands/system/test_reboot.py
+++ b/tests/commands/system/test_reboot.py
@@ -20,7 +20,7 @@ async def test_reboot_failure(mock_datagram_client):
                 _ = await client.system.reboot()
 
     assert str(err.value) == (
-        "reboot command failed (response: {'command': 2, 'status': 'error'})"
+        "system_reboot command failed (response: {'command': 2, 'status': 'error'})"
     )
 
 

--- a/tests/commands/system/test_upgrade_firmware.py
+++ b/tests/commands/system/test_upgrade_firmware.py
@@ -21,7 +21,8 @@ async def test_upgrade_firmware_failure(mock_datagram_client):
             client.disconnect()
 
     assert str(err.value) == (
-        "upgrade_firmware command failed (response: {'command': 4, 'status': 'error'})"
+        "system_upgrade_firmware command failed "
+        "(response: {'command': 4, 'status': 'error'})"
     )
 
 

--- a/tests/helpers/test_command.py
+++ b/tests/helpers/test_command.py
@@ -13,7 +13,7 @@ from aioguardian.helpers.command import (
 async def test_get_command_from_code():
     """Test the get_command_from_code helper."""
     real_command = get_command_from_code(0)
-    assert real_command == Command.ping
+    assert real_command == Command.system_ping
 
     with pytest.raises(CommandError) as err:
         _ = get_command_from_code(99999)
@@ -23,8 +23,8 @@ async def test_get_command_from_code():
 @pytest.mark.asyncio
 async def test_get_command_from_name():
     """Test the get_command_from_name helper."""
-    real_command = get_command_from_name("ping")
-    assert real_command == Command.ping
+    real_command = get_command_from_name("system_ping")
+    assert real_command == Command.system_ping
 
     with pytest.raises(CommandError) as err:
         _ = get_command_from_name("not real")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,7 +21,7 @@ async def test_command_timeout(mock_datagram_client):
             async with Client("192.168.1.100") as client:
                 await client.system.ping()
 
-        assert str(err.value) == "ping command timed out"
+        assert str(err.value) == "system_ping command timed out"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Following up on #51, this PR adjusts internal command names to match the public-facing API.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
