### PR TITLE
Allow None values for system.upgrade_firmware parameters

### DIFF
--- a/aioguardian/commands/system.py
+++ b/aioguardian/commands/system.py
@@ -1,6 +1,6 @@
 """Define system commands."""
 import asyncio
-from typing import Callable, Coroutine
+from typing import Any, Callable, Coroutine, Dict
 
 import voluptuous as vol
 
@@ -8,19 +8,15 @@ from aioguardian.errors import CommandError
 from aioguardian.helpers.command import Command
 import aioguardian.helpers.config_validation as cv
 
-DEFAULT_FIRMWARE_UPGRADE_FILENAME: str = "latest.bin"
-DEFAULT_FIRMWARE_UPGRADE_PORT: int = 443
-DEFAULT_FIRMWARE_UPGRADE_URL: str = "https://repo.guardiancloud.services/gvc/fw"
-
 PARAM_FILENAME: str = "filename"
 PARAM_PORT: str = "port"
 PARAM_URL: str = "url"
 
 UPGRADE_FIRMWARE_PARAM_SCHEMA: vol.Schema = vol.Schema(
     {
-        vol.Required(PARAM_URL): vol.All(cv.url, vol.Length(max=256)),
-        vol.Required(PARAM_PORT): int,
-        vol.Required(PARAM_FILENAME): vol.All(str, vol.Length(max=48)),
+        vol.Optional(PARAM_URL): vol.All(cv.url, vol.Length(max=256)),
+        vol.Optional(PARAM_PORT): int,
+        vol.Optional(PARAM_FILENAME): vol.All(str, vol.Length(max=48)),
     }
 )
 
@@ -95,24 +91,30 @@ class SystemCommands:
     async def upgrade_firmware(
         self,
         *,
-        url: str = DEFAULT_FIRMWARE_UPGRADE_URL,
-        port: int = DEFAULT_FIRMWARE_UPGRADE_PORT,
-        filename: str = DEFAULT_FIRMWARE_UPGRADE_FILENAME,
+        url: str = None,
+        port: int = None,
+        filename: str = None,
         silent: bool = True,
     ) -> dict:
         """Upgrade the firmware on the device.
 
-        :param url: The firmware file's URL
+        :param url: The firmware file's optional URL
         :type url: ``str``
-        :param port: The firmware file's port
+        :param port: The firmware file's optional port
         :type port: ``int``
-        :param filename: The firmware file's filename
+        :param filename: The firmware file's optional filename
         :type filename: ``str``
         :param silent: If ``True``, silence "beep" tones associated with this command
         :type silent: ``bool``
         :rtype: ``dict``
         """
-        params = {PARAM_URL: url, PARAM_PORT: port, PARAM_FILENAME: filename}
+        params: Dict[str, Any] = {}
+        if url:
+            params["url"] = url
+        if port:
+            params["port"] = port
+        if filename:
+            params["filename"] = filename
 
         try:
             UPGRADE_FIRMWARE_PARAM_SCHEMA(params)

--- a/tests/commands/system/test_upgrade_firmware.py
+++ b/tests/commands/system/test_upgrade_firmware.py
@@ -2,7 +2,7 @@
 import pytest
 
 from aioguardian import Client
-from aioguardian.errors import CommandError, GuardianError
+from aioguardian.errors import GuardianError
 
 from tests.common import load_fixture
 
@@ -10,20 +10,18 @@ from tests.common import load_fixture
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "command_response",
-    [load_fixture("upgrade_firmware_failure_response.json").encode()],
+    [load_fixture("upgrade_firmware_success_response.json").encode()],
 )
-async def test_upgrade_firmware_failure(mock_datagram_client):
-    """Test the upgrade_firmware command failing."""
+async def test_upgrade_firmware_custom_parameters(mock_datagram_client):
+    """Test that valid custom parameters work."""
     with mock_datagram_client:
-        with pytest.raises(CommandError) as err:
-            async with Client("192.168.1.100") as client:
-                _ = await client.system.upgrade_firmware()
-            client.disconnect()
+        async with Client("192.168.1.100") as client:
+            upgrade_firmware_response = await client.system.upgrade_firmware(
+                url="https://firmware.com", port=8080, filename="123.bin"
+            )
 
-        assert str(err.value) == (
-            "system_upgrade_firmware command failed "
-            "(response: {'command': 4, 'status': 'error'})"
-        )
+        assert upgrade_firmware_response["command"] == 4
+        assert upgrade_firmware_response["status"] == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

I learned today that you can run the `system.upgrade_firmware` command without any URL, port, or firmware file. This PR relaxes the previous requirement of defaults.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
