### PR TITLE
Handle asynctest not working in Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^((aioguardian|tests)/.+)?[^/]+\.py$
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.1.1
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.4
     hooks:
       - id: shellcheck
         args:

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,0 +1,9 @@
+"""Define async mocking that works for various Python versions."""
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import *  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import *  # noqa

--- a/tests/commands/system/test_reboot.py
+++ b/tests/commands/system/test_reboot.py
@@ -1,10 +1,10 @@
 """Test the reboot command."""
-from asynctest import CoroutineMock, patch
 import pytest
 
 from aioguardian import Client
 from aioguardian.errors import CommandError
 
+from tests.async_mock import AsyncMock, patch
 from tests.common import load_fixture
 
 
@@ -33,7 +33,7 @@ async def test_reboot_success(mock_datagram_client):
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
             # Patch asyncio.sleep so that this test doesn't take 3-ish seconds:
-            with patch("asyncio.sleep", CoroutineMock()):
+            with patch("asyncio.sleep", AsyncMock()):
                 reboot_response = await client.system.reboot()
 
         assert reboot_response["command"] == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 """Define generic fixtures for tests."""
 # pylint: disable=redefined-outer-name
-from asynctest import CoroutineMock, MagicMock, patch
 import pytest
+
+from tests.async_mock import AsyncMock, MagicMock, patch
 
 
 @pytest.fixture()
@@ -14,9 +15,9 @@ def command_response():
 def mock_datagram_client(recv_response):
     """Define a mocked datagram client."""
     mock_datagram_client = MagicMock()
-    mock_datagram_client.connect = CoroutineMock()
+    mock_datagram_client.connect = AsyncMock()
     mock_datagram_client.recv = recv_response
-    mock_datagram_client.send = CoroutineMock()
+    mock_datagram_client.send = AsyncMock()
     mock_datagram_client.close = MagicMock()
 
     with patch("asyncio_dgram.connect", return_value=mock_datagram_client):
@@ -26,7 +27,7 @@ def mock_datagram_client(recv_response):
 @pytest.fixture()
 def recv_response(command_response, remote_addr_response):
     """Define a response from the socket."""
-    return CoroutineMock(return_value=(command_response, remote_addr_response))
+    return AsyncMock(return_value=(command_response, remote_addr_response))
 
 
 @pytest.fixture()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,17 @@
 """Test generic client characteristics."""
 import asyncio
 
-from asynctest import CoroutineMock, patch
 import pytest
 
 from aioguardian import Client
 from aioguardian.errors import SocketError
 
+from tests.async_mock import AsyncMock, patch
 from tests.common import load_fixture
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "recv_response", [CoroutineMock(side_effect=asyncio.TimeoutError)]
-)
+@pytest.mark.parametrize("recv_response", [AsyncMock(side_effect=asyncio.TimeoutError)])
 async def test_command_timeout(mock_datagram_client):
     """Test that a timeout during command execution throws an exception."""
     with mock_datagram_client, patch("asyncio.sleep"):
@@ -54,9 +52,7 @@ async def test_command_without_socket_connect():
 @pytest.mark.asyncio
 async def test_connect_timeout():
     """Test that a timeout during connection throws an exception."""
-    with patch(
-        "asyncio_dgram.connect", CoroutineMock(side_effect=asyncio.TimeoutError)
-    ):
+    with patch("asyncio_dgram.connect", AsyncMock(side_effect=asyncio.TimeoutError)):
         with pytest.raises(SocketError) as err:
             async with Client("192.168.1.100") as client:
                 await client.system.ping()


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes the fact that `asynctest` no longer works in Python 3.8. The PR still ensures that it can be used for Python 3.6 and 3.7.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioguardian/issues/59
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
