### PR TITLE
Update voluptuous requirement from ^0.11.7 to >=0.11.7,<0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ aiohttp = "^3.6.2"
 async_timeout = "^3.0.1"
 asyncio_dgram = "^1.0.1"
 python = "^3.6.1"
-voluptuous = "^0.11.7"
+voluptuous = ">=0.11.7,<0.13.0"
 
 [tool.poetry.dev-dependencies]
 Sphinx = "^3.0.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,4 +8,4 @@ pytest-aiohttp==0.3.0
 pytest-asyncio==0.10.0
 pytest-cov==2.8.1
 pytest==5.3.5
-voluptuous==0.11.7
+voluptuous>=0.11.7,<0.13.0


### PR DESCRIPTION
For reference:
- https://pypi.org/project/voluptuous/0.12.0/#files
- https://github.com/bachya/simplisafe-python/pull/174
- https://github.com/home-assistant/core/pull/40401#issuecomment-697283168

**Describe what the PR does:**
Updates the requirements on [voluptuous](https://github.com/alecthomas/voluptuous) to permit the latest version.
- [Release notes](https://github.com/alecthomas/voluptuous/releases)
- [Changelog](https://github.com/alecthomas/voluptuous/blob/master/CHANGELOG.md)
- [Commits](https://github.com/alecthomas/voluptuous/commits/v0.12.0)

**Does this fix a specific issue?**
- Resolves dependency conflicts with other modules that depend on latest voluptuous.
- Additionally: https://github.com/home-assistant/core/pull/40401#issue-490153791

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`. (Probably a bid too trivial and copy&paste from dependabot to call myself an "author" 😉)