### PR TITLE
Allow later asyncio_dgram releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
 async_timeout = "^3.0.1"
-asyncio_dgram = "^1.0.1"
+asyncio_dgram = "^2.0.0"
 python = "^3.6.1"
 voluptuous = ">=0.11.7,<0.13.0"
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.7.4
 aresponses==1.1.2
 async_timeout==3.0.1
-asyncio_dgram==1.0.1
+asyncio_dgram==2.0.0
 asynctest==0.13.0
 pre-commit==2.0.1
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
**Describe what the PR does:**
Allow later `asyncio_dgram` releases. According to the [ChangeLog](https://github.com/jsbronder/asyncio-dgram/blob/master/ChangeLog) does the releases not contain breaking changes.

**Does this fix a specific issue?**
Distributions are starting to ship `asyncio_dgram` > 2. This is an issue for NixOS as others as `aioguardian` fails to build.
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
