### PR TITLE
Use poetry-core as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry-core"]
+requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry-core >= 1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
+requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]


### PR DESCRIPTION
**Describe what the PR does:**

Pull-in only `poetry-core`.

**Does this fix a specific issue?**

This allow distributions to only depend on the build backend and not the full poetry package.
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
