### PR TITLE
Relax async-timeout dependency version constrain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4post0"
-async_timeout = "^3.0.1"
+async_timeout = ">=3.0.1,<5.0.0"
 asyncio_dgram = "^2.0.0"
 docutils = "<0.18"
 python = "^3.6.1"


### PR DESCRIPTION
**Describe what the PR does:**

Relaxes the async-timeout version constrains.

**Does this fix a specific issue?**

Home Assistant uses 4.0.0

```
ERROR: Cannot install -r requirements_test_all.txt (line 118), -r requirements_test_all.txt (line 24) and -r requirements_test_all.txt (line 54) because these package versions have conflicting dependencies.

The conflict is caused by:
    pyrmvtransport 0.3.2 depends on async-timeout
    adax 0.1.1 depends on async-timeout>=1.4.0
    aioguardian 1.0.8 depends on async_timeout<4.0.0 and >=3.0.1
    The user requested (constraint) async-timeout==4.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
