### PR TITLE
Loosen dependency pin for voluptuous

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - --configfile=.bandit.yaml
         files: ^aioguardian/.+\.py$
   - repo: https://github.com/python/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ aiohttp = ">=3.8.0"
 asyncio_dgram = "^2.0.0"
 docutils = "<0.19"
 python = "^3.6.1"
-voluptuous = ">=0.11.7,<0.13.0"
+voluptuous = ">=0.13.0"
 
 [tool.poetry.dev-dependencies]
 Sphinx = "^4.0.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ asynctest==0.13.0
 pytest-aiohttp==0.3.0
 pytest-cov==3.0.0
 pytest==6.2.5
-voluptuous>=0.11.7,<0.13.0
+voluptuous==0.13.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR loosens the dependency pinning for `voluptuous`. It tangentially updates the version of `black` used in `pre-commit` to resolve conflicts.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioguardian/issues/81
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
