### PR TITLE
Ensure docs are covered by pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v1.16.0
     hooks:
@@ -41,7 +41,7 @@ repos:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(aioguardian|tests)/.+\.py$
+        files: ^(aioguardian|docs|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.950
     hooks:
@@ -62,7 +62,7 @@ repos:
     rev: 5.0.2
     hooks:
       - id: pydocstyle
-        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.12
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+"""Define docs configuration."""
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -14,7 +15,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 from datetime import datetime
-
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR follows up on #96 to ensure that the `docs/` folder is also covered by pre-commit hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
