### PR TITLE
Guard against forced disconnections

### DIFF
--- a/aioguardian/client.py
+++ b/aioguardian/client.py
@@ -128,8 +128,9 @@ class Client:  # pylint: disable=too-many-instance-attributes
 
     def disconnect(self) -> None:
         """Close the connection."""
-        self._stream.close()
-        self._stream = None
+        if self._stream:
+            self._stream.close()
+            self._stream = None
 
     async def execute_raw_command(
         self, command_code: int, *, params: dict | None = None, silent: bool = True


### PR DESCRIPTION
**Describe what the PR does:**

In some cases (like when pairing a sensor), the Guardian socket connection will force close after it completes – not sure why. In the current code, that throws an exception because we try to close a closed connection.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
