### PR TITLE
Update CI to use GA release of Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-rc.2"
+          - "3.11.0"
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
-        files: ^aioflo/.+\.py$
+        files: ^aioguardian/.+\.py$
   - repo: https://github.com/python/black
     rev: 22.10.0
     hooks:
@@ -17,7 +17,7 @@ repos:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((aioflo|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
@@ -34,19 +34,19 @@ repos:
           - flake8-bugbear
           - flake8-docstrings
           - pydocstyle
-        files: ^aioflo/.+\.py$
+        files: ^aioguardian/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(aioflo|tests)/.+\.py$
+        files: ^(aioguardian|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
       - id: mypy
-        files: ^aioflo/.+\.py$
+        files: ^aioguardian/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -62,7 +62,7 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        files: ^((aioflo|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.17
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
@@ -41,7 +41,7 @@ repos:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(aioguardian|tests)/.+\.py$
+        files: ^(aioguardian|docs|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
@@ -62,7 +62,7 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        files: ^((aioguardian|tests)/.+)?[^/]+\.py$
+        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.17
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,18 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
-        files: ^aioguardian/.+\.py$
+        files: ^aioflo/.+\.py$
   - repo: https://github.com/python/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         args:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
+        files: ^((aioflo|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args:
@@ -27,26 +27,26 @@ repos:
           - --quiet-level=4
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-docstrings
           - pydocstyle
-        files: ^aioguardian/.+\.py$
+        files: ^aioflo/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(aioguardian|docs|tests)/.+\.py$
+        files: ^(aioflo|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.982
     hooks:
       - id: mypy
-        files: ^aioguardian/.+\.py$
+        files: ^aioflo/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -62,13 +62,13 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        files: ^((aioguardian|docs|tests)/.+)?[^/]+\.py$
+        files: ^((aioflo|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.17
     hooks:
       - id: shellcheck
         files: ^script/.+
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v3.1.0
     hooks:
       - id: pyupgrade

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ pip install aioguardian
 
 `aioguardian` is currently supported on:
 
-* Python 3.8
 * Python 3.9
 * Python 3.10
 * Python 3.11

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,6 @@ pip install aioguardian
 
 `aioguardian` is currently supported on:
 
-- Python 3.8
 - Python 3.9
 - Python 3.10
 - Python 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ disallow_untyped_defs = true
 follow_imports = "silent"
 ignore_missing_imports = true
 no_implicit_optional = true
-python_version = "3.8"
+python_version = "3.10"
 show_error_codes = true
 strict_equality = true
 warn_incomplete_stub = true
@@ -56,7 +56,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -67,7 +66,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = ">=3.8.0"
 asyncio_dgram = "^2.0.0"
-python = "^3.8.0"
+python = ">=3.9.0"
 voluptuous = ">=0.11.7"
 
 [tool.poetry.dev-dependencies]

--- a/tests/commands/system/test_ping.py
+++ b/tests/commands/system/test_ping.py
@@ -12,7 +12,7 @@ from tests.common import load_fixture
     "command_response", [load_fixture("ping_failure_response.json").encode()]
 )
 async def test_ping_failure(mock_datagram_client):
-    """Test a failured ping of the device."""
+    """Test a failed ping of the device."""
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
             async with Client("192.168.1.100") as client:


### PR DESCRIPTION
**Describe what the PR does:**

Happy Python 3.11 release day! This PR updates CI to tests against the GA release. Per our standards of supporting the three most recent versions, this PR also removes official support for anything before 3.9.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
