### PR TITLE
Remove incorrect warning about cached WiFi SSIDs

### DIFF
--- a/aioguardian/commands/wifi.py
+++ b/aioguardian/commands/wifi.py
@@ -41,7 +41,6 @@ class WiFiCommands:
             execute_command: The execute_command method from the Client object.
         """
         self._execute_command = execute_command
-        self._scan_performed = False
 
     async def configure(
         self, ssid: str, password: str, *, silent: bool = True
@@ -101,14 +100,7 @@ class WiFiCommands:
         Returns:
             An API response payload.
         """
-        if not self._scan_performed:
-            _LOGGER.warning(
-                "Returning cached SSIDs; run wifi_scan first for up-to-date data"
-            )
-
-        data = await self._execute_command(Command.WIFI_LIST, silent=silent)
-        self._scan_performed = False
-        return data
+        return await self._execute_command(Command.WIFI_LIST, silent=silent)
 
     async def reset(self, *, silent: bool = True) -> dict[str, Any]:
         """Erase and reset all WiFi settings.
@@ -130,9 +122,7 @@ class WiFiCommands:
         Returns:
             An API response payload.
         """
-        data = await self._execute_command(Command.WIFI_SCAN, silent=silent)
-        self._scan_performed = True
-        return data
+        return await self._execute_command(Command.WIFI_SCAN, silent=silent)
 
     async def status(self, *, silent: bool = True) -> dict[str, Any]:
         """Return the current WiFi status of the device.

--- a/tests/commands/wifi/test_list.py
+++ b/tests/commands/wifi/test_list.py
@@ -1,5 +1,5 @@
 """Test the list command."""
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -32,23 +32,16 @@ async def test_list_failure(mock_datagram_client: MagicMock) -> None:
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_list_success_response.json").encode()]
 )
-async def test_list_success(caplog: Mock, mock_datagram_client: MagicMock) -> None:
+async def test_list_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_list command succeeding.
 
     Args:
-        caplog: A mocked logging facility.
         mock_datagram_client: A mocked UDP client.
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
             await client.wifi.scan()
             wifi_list_response = await client.wifi.list()
-
-        assert all(
-            "Returning cached SSIDs; run wifi_scan first for up-to-date data"
-            not in e.message
-            for e in caplog.records
-        )
 
         assert wifi_list_response["command"] == 38
         assert wifi_list_response["status"] == "ok"
@@ -70,24 +63,15 @@ async def test_list_success(caplog: Mock, mock_datagram_client: MagicMock) -> No
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_list_success_response.json").encode()]
 )
-async def test_list_success_cached(
-    caplog: Mock, mock_datagram_client: MagicMock
-) -> None:
+async def test_list_success_cached(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_list command succeeding after a cache.
 
     Args:
-        caplog: A mocked logging facility.
         mock_datagram_client: A mocked UDP client.
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
             wifi_list_response = await client.wifi.list()
-
-        assert any(
-            "Returning cached SSIDs; run wifi_scan first for up-to-date data"
-            in e.message
-            for e in caplog.records
-        )
 
         assert wifi_list_response["command"] == 38
         assert wifi_list_response["status"] == "ok"


### PR DESCRIPTION
**Describe what the PR does:**

SSIA. This was only useful when first called; after, we might incorrectly prompt the user to believe that results are fresh when they aren't.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioguardian/issues/<ISSUE ID>

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
