### PR TITLE
ci: renovate use of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,17 +85,15 @@ repos:
         language: system
         types: [python]
         entry: poetry run ruff format
-      - id: isort
-        name: 🔀 Sorting all imports with isort
-        language: system
-        types: [python]
-        entry: poetry run isort
+        exclude: |
+          (?x)^($^
+          |docs/.*
+          )$
       - id: mypy
         name: 🆎 Performing static type checking using mypy
         language: system
         types: [python]
         entry: poetry run mypy
-        require_serial: true
       - id: no-commit-to-branch
         name: 🛑 Checking for commit to protected branch
         language: system
@@ -116,37 +114,25 @@ repos:
         language: system
         types: [python]
         entry: poetry run pylint
-        exclude: ^docs\/conf.py$
-      - id: pyupgrade
-        name: 🆙 Checking for upgradable syntax with pyupgrade
-        language: system
-        types: [python]
-        entry: poetry run pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
+        exclude: |
+          (?x)^($^
+          |docs/.*
+          )$
       - id: ruff
         name: 👔 Enforcing style guide with ruff
         language: system
         types: [python]
-        entry: poetry run ruff --fix
-        exclude: ^docs\/conf.py$
+        entry: poetry run ruff check --fix
+        exclude: |
+          (?x)^($^
+          |docs/.*
+          )$
       - id: trailing-whitespace
         name: ✄  Trimming trailing whitespace
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
         stages: [commit, push, manual]
-      - id: vulture
-        name: 🔍 Finding unused Python code with Vulture
-        language: system
-        types: [python]
-        entry: poetry run vulture
-        pass_filenames: false
-        require_serial: true
-      - id: yamllint
-        name: 🎗  Checking YAML files with yamllint
-        language: system
-        types: [yaml]
-        entry: poetry run yamllint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/aioguardian/__init__.py
+++ b/aioguardian/__init__.py
@@ -1,3 +1,7 @@
 """Define the aioguardian package."""
 
-from aioguardian.client import Client  # noqa
+from aioguardian.client import Client
+
+__all__ = [
+    "Client",
+]

--- a/aioguardian/commands/iot.py
+++ b/aioguardian/commands/iot.py
@@ -16,7 +16,9 @@ class IOTCommands:  # pylint: disable=too-few-public-methods
     ``client.iot``).
 
     Args:
+    ----
         execute_command: The execute_command method from the Client object.
+
     """
 
     def __init__(
@@ -25,7 +27,9 @@ class IOTCommands:  # pylint: disable=too-few-public-methods
         """Initialize.
 
         Args:
+        ----
             execute_command: The execute_command method from the Client object.
+
         """
         self._execute_command = execute_command
 
@@ -33,9 +37,12 @@ class IOTCommands:  # pylint: disable=too-few-public-methods
         """Publish the device's complete state to the Guardian cloud.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.IOT_PUBLISH_STATE, silent=silent)

--- a/aioguardian/commands/sensor.py
+++ b/aioguardian/commands/sensor.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import voluptuous as vol
 
-import aioguardian.helpers.config_validation as cv
 from aioguardian.errors import CommandError
 from aioguardian.helpers.command import Command
+import aioguardian.helpers.config_validation as cv
 
 PARAM_UID = "uid"
 
@@ -26,7 +26,9 @@ class SensorCommands:
     ``client.sensor``).
 
     Args:
+    ----
         execute_command: The execute_command method from the Client object.
+
     """
 
     def __init__(
@@ -35,7 +37,9 @@ class SensorCommands:
         """Initialize.
 
         Args:
+        ----
             execute_command: The execute_command method from the Client object.
+
         """
         self._execute_command = execute_command
 
@@ -43,10 +47,13 @@ class SensorCommands:
         """Dump information on all paired sensors.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.SENSOR_PAIR_DUMP, silent=silent)
 
@@ -54,21 +61,26 @@ class SensorCommands:
         """Pair a new sensor to the device.
 
         Args:
+        ----
             uid: A UID of a Guardian paired sensor.
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             CommandError: Raised when invalid parameters are provided.
+
         """
         params = {PARAM_UID: uid}
 
         try:
             PAIRED_SENSOR_UID_SCHEMA(params)
         except vol.Invalid as err:
-            raise CommandError(f"Invalid parameters provided: {err}") from None
+            msg = f"Invalid parameters provided: {err}"
+            raise CommandError(msg) from err
 
         return await self._execute_command(
             Command.SENSOR_PAIR_SENSOR, params=params, silent=silent
@@ -80,21 +92,26 @@ class SensorCommands:
         """Get the status (leak, temperature, etc.) of a paired sensor.
 
         Args:
+        ----
             uid: A UID of a Guardian paired sensor.
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             CommandError: Raised when invalid parameters are provided.
+
         """
         params = {PARAM_UID: uid}
 
         try:
             PAIRED_SENSOR_UID_SCHEMA(params)
         except vol.Invalid as err:
-            raise CommandError(f"Invalid parameters provided: {err}") from None
+            msg = f"Invalid parameters provided: {err}"
+            raise CommandError(msg) from err
 
         return await self._execute_command(
             Command.SENSOR_PAIRED_SENSOR_STATUS, params=params, silent=silent
@@ -104,21 +121,26 @@ class SensorCommands:
         """Unpair a sensor from the device.
 
         Args:
+        ----
             uid: A UID of a Guardian paired sensor.
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             CommandError: Raised when invalid parameters are provided.
+
         """
         params = {PARAM_UID: uid}
 
         try:
             PAIRED_SENSOR_UID_SCHEMA(params)
         except vol.Invalid as err:
-            raise CommandError(f"Invalid parameters provided: {err}") from None
+            msg = f"Invalid parameters provided: {err}"
+            raise CommandError(msg) from err
 
         return await self._execute_command(
             Command.SENSOR_UNPAIR_SENSOR, params=params, silent=silent

--- a/aioguardian/commands/system.py
+++ b/aioguardian/commands/system.py
@@ -8,9 +8,9 @@ from typing import Any
 
 import voluptuous as vol
 
-import aioguardian.helpers.config_validation as cv
 from aioguardian.errors import CommandError
 from aioguardian.helpers.command import Command
+import aioguardian.helpers.config_validation as cv
 
 PARAM_FILENAME = "filename"
 PARAM_PORT = "port"
@@ -33,7 +33,9 @@ class SystemCommands:
     ``client.system``).
 
     Args:
+    ----
         execute_command: The execute_command method from the Client object.
+
     """
 
     def __init__(
@@ -42,7 +44,9 @@ class SystemCommands:
         """Initialize.
 
         Args:
+        ----
             execute_command: The execute_command method from the Client object.
+
         """
         self._execute_command = execute_command
 
@@ -50,10 +54,13 @@ class SystemCommands:
         """Retrieve diagnostics info.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.SYSTEM_DIAGNOSTICS, silent=silent)
 
@@ -61,10 +68,13 @@ class SystemCommands:
         """Perform a factory reset on the device.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.SYSTEM_FACTORY_RESET, silent=silent)
 
@@ -72,10 +82,13 @@ class SystemCommands:
         """Retrieve status of the valve controller's onboard sensors.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(
             Command.SYSTEM_ONBOARD_SENSOR_STATUS, silent=silent
@@ -85,10 +98,13 @@ class SystemCommands:
         """Ping the device.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.SYSTEM_PING, silent=silent)
 
@@ -96,15 +112,18 @@ class SystemCommands:
         """Reboot the device.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         data = await self._execute_command(Command.SYSTEM_REBOOT, silent=silent)
 
         # The Guardian API docs indicate that the reboot will occur "3 seconds after
-        # command is received" – in order to guard against errors from subsequent
+        # command is received." In order to guard against errors from subsequent
         # commands while the reboot is occurring, we sleep for 3 seconds before
         # returning the response:
         await asyncio.sleep(3)
@@ -122,16 +141,20 @@ class SystemCommands:
         """Upgrade the firmware on the device.
 
         Args:
+        ----
             url: A Guardian-provided URL that hosts firmware files.
             port: A port at the Guardian-provided URL that can be accessed.
             filename: A firmware filename.
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             CommandError: Raised when invalid parameters are provided.
+
         """
         params: dict[str, int | str] = {}
         if url:
@@ -144,7 +167,8 @@ class SystemCommands:
         try:
             UPGRADE_FIRMWARE_PARAM_SCHEMA(params)
         except vol.Invalid as err:
-            raise CommandError(f"Invalid parameters provided: {err}") from None
+            msg = f"Invalid parameters provided: {err}"
+            raise CommandError(msg) from err
 
         return await self._execute_command(
             Command.SYSTEM_UPGRADE_FIRMWARE, params=params, silent=silent

--- a/aioguardian/commands/valve.py
+++ b/aioguardian/commands/valve.py
@@ -1,5 +1,7 @@
 """Define valve commands."""
 
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -31,7 +33,9 @@ class ValveCommands:
     ``client.valve``).
 
     Args:
+    ----
         execute_command: The execute_command method from the Client object.
+
     """
 
     def __init__(
@@ -40,15 +44,19 @@ class ValveCommands:
         """Initialize.
 
         Args:
+        ----
             execute_command: The execute_command method from the Client object.
+
         """
         self._execute_command = execute_command
 
     async def close(self) -> dict[str, Any]:
         """Close the valve.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.VALVE_CLOSE)
 
@@ -59,8 +67,10 @@ class ValveCommands:
         events; therefore, it is not recommended to leave the device in a "halted" state
         indefinitely.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         LOGGER.warning(
             "The device will not respond to leak events while in a halted state. It is "
@@ -72,8 +82,10 @@ class ValveCommands:
     async def open(self) -> dict[str, Any]:
         """Open the valve.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.VALVE_OPEN)
 
@@ -84,10 +96,13 @@ class ValveCommands:
         lifetime average current draw) and cannot be undone.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.VALVE_RESET, silent=silent)
 
@@ -112,10 +127,13 @@ class ValveCommands:
             * ``start_opening``
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         data = await self._execute_command(Command.VALVE_STATUS, silent=silent)
         data["data"]["state"] = VALVE_STATE_MAPPING[data["data"]["state"]]

--- a/aioguardian/commands/wifi.py
+++ b/aioguardian/commands/wifi.py
@@ -1,5 +1,7 @@
 """Define WiFi commands."""
 
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -27,7 +29,9 @@ class WiFiCommands:
     ``client.wifi``).
 
     Args:
+    ----
         execute_command: The execute_command method from the Client object.
+
     """
 
     def __init__(
@@ -36,7 +40,9 @@ class WiFiCommands:
         """Initialize.
 
         Args:
+        ----
             execute_command: The execute_command method from the Client object.
+
         """
         self._execute_command = execute_command
 
@@ -46,22 +52,27 @@ class WiFiCommands:
         """Configure the device to use a wireless network.
 
         Args:
+        ----
             ssid: An SSID to connect to.
             password: The password to use to connect to the SSID.
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             CommandError: Raised when invalid parameters are provided.
+
         """
         params = {PARAM_SSID: ssid, PARAM_PASSWORD: password}
 
         try:
             WIFI_CONFIGURE_PARAM_SCHEMA(params)
         except vol.Invalid as err:
-            raise CommandError(f"Invalid parameters provided: {err}") from None
+            msg = f"Invalid parameters provided: {err}"
+            raise CommandError(msg) from err
 
         return await self._execute_command(
             Command.WIFI_CONFIGURE, params=params, silent=silent
@@ -71,10 +82,13 @@ class WiFiCommands:
         """Disable the device's onboard WiFi access point.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_DISABLE_AP, silent=silent)
 
@@ -82,10 +96,13 @@ class WiFiCommands:
         """Enable the device's onboard WiFi access point.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_ENABLE_AP, silent=silent)
 
@@ -93,10 +110,13 @@ class WiFiCommands:
         """List previously scanned nearby SSIDs.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_LIST, silent=silent)
 
@@ -104,10 +124,13 @@ class WiFiCommands:
         """Erase and reset all WiFi settings.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_RESET, silent=silent)
 
@@ -115,10 +138,13 @@ class WiFiCommands:
         """Scan for nearby SSIDs.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_SCAN, silent=silent)
 
@@ -126,9 +152,12 @@ class WiFiCommands:
         """Return the current WiFi status of the device.
 
         Args:
+        ----
             silent: Whether the valve controller should beep upon successful command.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._execute_command(Command.WIFI_STATUS, silent=silent)

--- a/aioguardian/errors.py
+++ b/aioguardian/errors.py
@@ -20,39 +20,36 @@ ERROR_CODE_MAPPING = {
 class GuardianError(Exception):
     """Define a base error from which all others inherit."""
 
-    pass
-
 
 class CommandError(GuardianError):
     """Define an error related to commands (invalid commands, invalid params, etc.)."""
 
-    pass
-
 
 class SocketError(GuardianError):
     """Define an error related to UDP socket issues."""
-
-    pass
 
 
 def _raise_on_command_error(command: Command, data: dict[str, Any]) -> None:
     """Examine a data response and raise errors appropriately.
 
     Args:
+    ----
         command: The command to execute.
         data: An API response payload.o
 
     Raises:
+    ------
         CommandError: Raised when a command fails for any reason.
+
     """
     if data.get("status") == "ok":
         return
 
     # If we know exactly why the command failed, raise that error:
     if data.get("error_code") in ERROR_CODE_MAPPING:
-        raise CommandError(
-            f"{command.name} command failed: {ERROR_CODE_MAPPING[data['error_code']]}"
-        )
+        msg = f"{command.name} command failed: {ERROR_CODE_MAPPING[data['error_code']]}"
+        raise CommandError(msg)
 
     # Last resort, return a generic error with the response payload:
-    raise CommandError(f"{command.name} command failed (response: {data})")
+    msg = f"{command.name} command failed (response: {data})"
+    raise CommandError(msg)

--- a/aioguardian/helpers/command.py
+++ b/aioguardian/helpers/command.py
@@ -37,18 +37,23 @@ def get_command_from_name(command_name: str) -> Command:
     """Return the command for a particular name.
 
     Args:
+    ----
         command_name: The command string to parse into a Command.
 
     Returns:
+    -------
         A Command object.
 
     Raises:
+    ------
         CommandError: Raised when an unknown command is encountered.
+
     """
     try:
         command = Command[command_name]
-    except KeyError:
-        raise CommandError(f"Unknown command name: {command_name}") from None
+    except KeyError as err:
+        msg = f"Unknown command name: {command_name}"
+        raise CommandError(msg) from err
     return command
 
 
@@ -56,16 +61,21 @@ def get_command_from_code(command_code: int) -> Command:
     """Return the command for a particular code.
 
     Args:
+    ----
         command_code: The raw command code to parse into a Command.
 
     Returns:
+    -------
         A Command object.
 
     Raises:
+    ------
         CommandError: Raised when an unknown command is encountered.
+
     """
     try:
         command = Command(command_code)
-    except ValueError:
-        raise CommandError(f"Unknown command code: {command_code}") from None
+    except ValueError as err:
+        msg = f"Unknown command code: {command_code}"
+        raise CommandError(msg) from err
     return command

--- a/aioguardian/helpers/config_validation.py
+++ b/aioguardian/helpers/config_validation.py
@@ -1,42 +1,51 @@
 """Define custom validators."""
 
-from typing import Any, cast
+from typing import cast
 from urllib.parse import urlparse
 
 import voluptuous as vol
 
 
-def alphanumeric(value: Any) -> str:
+def alphanumeric(value: str) -> str:
     """Validate that a string is alphanumeric only.
 
     Args:
+    ----
         value: A value to evaluae.
 
     Returns:
+    -------
         An alphanumeric string.
 
     Raises:
+    ------
         Invalid: Raised when a non-alphanumeric string is encountered.
+
     """
     str_value = str(value)
 
     if str_value.isalnum():
         return str_value
 
-    raise vol.Invalid("String is not alphanumeric")
+    msg = "String is not alphanumeric"
+    raise vol.Invalid(msg)
 
 
-def url(value: Any) -> str:
+def url(value: str) -> str:
     """Validate that a string is a URL.
 
     Args:
+    ----
         value: A value to evaluae.
 
     Returns:
+    -------
         An URL string.
 
     Raises:
+    ------
         Invalid: Raised when a non-URL string is encountered.
+
     """
     url_in = str(value)
 
@@ -46,4 +55,5 @@ def url(value: Any) -> str:
             vol.Schema(vol.Url())(url_in),  # pylint: disable=no-value-for-parameter
         )
 
-    raise vol.Invalid("Invalid URL")
+    msg = "Invalid URL"
+    raise vol.Invalid(msg)

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Define examples."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ myst-parser = ">=0.18,<2.1"
 Changelog = "https://github.com/bachya/aioguardian/releases"
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint.DESIGN]
@@ -110,44 +111,312 @@ max-attributes = 20
 [tool.pylint.FORMAT]
 max-line-length = 88
 
-[tool.pylint.MASTER]
+[tool.pylint.MAIN]
+py-version = "3.12"
 ignore = [
-  "tests",
+    "tests",
 ]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook = """\
+    from pathlib import Path; \
+    import sys; \
+
+    from pylint.config import find_default_config_files; \
+
+    sys.path.append( \
+        str(Path(next(find_default_config_files())).parent.joinpath('pylint/plugins'))
+    ) \
+    """
 load-plugins = [
-  "pylint.extensions.bad_builtin",
-  "pylint.extensions.code_style",
-  "pylint.extensions.docparams",
-  "pylint.extensions.docstyle",
-  "pylint.extensions.empty_comment",
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.typing",
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+]
+persistent = false
+fail-on = [
+    "I",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]
-# Reasons disabled:
-# unnecessary-pass - This can hurt readability
 disable = [
-  "unnecessary-pass"
+    # These are subjective and should be left up to the developer:
+    "too-many-arguments",
+    "too-many-lines",
+    "too-many-locals",
+    "duplicate-code",
+
+    # Handled by ruff:
+    # Ref: <https://github.com/astral-sh/ruff/issues/970>
+    "anomalous-backslash-in-string",        # W605
+    "assert-on-string-literal",             # PLW0129
+    "assert-on-tuple",                      # F631
+    "await-outside-async",                  # PLE1142
+    "bad-classmethod-argument",             # N804
+    "bad-format-string",                    # W1302, F
+    "bad-format-string-key",                # W1300, F
+    "bad-str-strip-call",                   # PLE1310
+    "bad-string-format-type",               # PLE1307
+    "bare-except",                          # E722
+    "bidirectional-unicode",                # PLE2502
+    "binary-op-exception",                  # PLW0711
+    "broad-exception-caught",               # W0718
+    "cell-var-from-loop",                   # B023
+    "comparison-of-constants",              # PLR0133
+    "comparison-with-itself",               # PLR0124
+    "consider-alternative-union-syntax",    # UP007
+    "consider-iterating-dictionary",        # SIM118
+    "consider-merging-isinstance",          # PLR1701
+    "consider-using-alias",                 # UP006
+    "consider-using-dict-comprehension",    # C402
+    "consider-using-generator",             # C417
+    "consider-using-get",                   # SIM401
+    "consider-using-set-comprehension",     # C401
+    "consider-using-sys-exit",              # PLR1722
+    "consider-using-ternary",               # SIM108
+    "continue-in-finally",                  # PLE0116
+    "duplicate-bases",                      # PLE0241
+    "duplicate-except",                     # B014
+    "duplicate-key",                        # F601
+    "duplicate-string-formatting-argument", # F
+    "duplicate-value",                      # F
+    "empty-docstring",                      # D419
+    "eval-used",                            # S307
+    "exec-used",                            # S102
+    "expression-not-assigned",              # B018
+    "f-string-without-interpolation",       # F541
+    "forgotten-debug-statement",            # T100
+    "format-needs-mapping",                 # F502
+    "format-string-without-interpolation",  # F
+    "function-redefined",                   # F811
+    "global-variable-not-assigned",         # PLW0602
+    "implicit-str-concat",                  # ISC001
+    "import-self",                          # PLW0406
+    "inconsistent-quotes",                  # Q000
+    "invalid-all-object",                   # PLE0604
+    "invalid-character-backspace",          # PLE2510
+    "invalid-character-esc",                # PLE2513
+    "invalid-character-nul",                # PLE2514
+    "invalid-character-sub",                # PLE2512
+    "invalid-character-zero-width-space",   # PLE2515
+    "invalid-envvar-default",               # PLW1508
+    "invalid-name",                         # N815
+    "keyword-arg-before-vararg",            # B026
+    "line-too-long",                        # E501
+    "literal-comparison",                   # F632
+    "logging-format-interpolation",         # G
+    "logging-fstring-interpolation",        # G
+    "logging-not-lazy",                     # G
+    "logging-too-few-args",                 # PLE1206
+    "logging-too-many-args",                # PLE1205
+    "misplaced-future",                     # F404
+    "missing-class-docstring",              # D101
+    "missing-final-newline",                # W292
+    "missing-format-string-key",            # F524
+    "missing-function-docstring",           # D103
+    "missing-module-docstring",             # D100
+    "mixed-format-string",                  # F506
+    "multiple-imports",                     #E401
+    "named-expr-without-context",           # PLW0131
+    "nested-min-max",                       # PLW3301
+    "no-method-argument",                   # N805
+    "no-self-argument",                     # N805
+    "nonexistent-operator",                 # B002
+    "nonlocal-without-binding",             # PLE0117
+    "not-in-loop",                          # F701, F702
+    "notimplemented-raised",                # F901
+    "pointless-statement",                  # B018
+    "property-with-parameters",             # PLR0206
+    "raise-missing-from",                   # B904
+    "return-in-init",                       # PLE0101
+    "return-outside-function",              # F706
+    "singleton-comparison",                 # E711, E712
+    "subprocess-run-check",                 # PLW1510
+    "super-with-arguments",                 # UP008
+    "superfluous-parens",                   # UP034
+    "syntax-error",                         # E999
+    "too-few-format-args",                  # F524
+    "too-many-branches",                    # PLR0912
+    "too-many-format-args",                 # F522
+    "too-many-return-statements",           # PLR0911
+    "too-many-star-expressions",            # F622
+    "too-many-statements",                  # PLR0915
+    "trailing-comma-tuple",                 # COM818
+    "truncated-format-string",              # F501
+    "try-except-raise",                     # TRY302
+    "undefined-all-variable",               # F822
+    "undefined-variable",                   # F821
+    "ungrouped-imports",                    # I001
+    "unidiomatic-typecheck",                # E721
+    "unnecessary-comprehension",            # C416
+    "unnecessary-direct-lambda-call",       # PLC3002
+    "unnecessary-lambda-assignment",        # PLC3001
+    "unnecessary-pass",                     # PIE790
+    "unneeded-not",                         # SIM208
+    "unused-argument",                      # ARG001
+    "unused-format-string-argument",        # F507
+    "unused-format-string-key",             # F504
+    "unused-import",                        # F401
+    "unused-variable",                      # F841
+    "use-a-generator",                      # C417
+    "use-dict-literal",                     # C406
+    "use-list-literal",                     # C405
+    "used-prior-global-declaration",        # PLE0118
+    "useless-else-on-loop",                 # PLW0120
+    "useless-import-alias",                 # PLC0414
+    "useless-object-inheritance",           # UP004
+    "useless-return",                       # PLR1711
+    "wildcard-import",                      # F403
+    "wrong-import-order",                   # I001
+    "wrong-import-position",                # E402
+    "yield-inside-async-function",          # PLE1700
+    "yield-outside-function",               # F704
+
+    # Handled by mypy:
+    # Ref: <https://github.com/antonagestam/pylint-mypy-overlap>
+    "abstract-class-instantiated",
+    "arguments-differ",
+    "assigning-non-slot",
+    "assignment-from-no-return",
+    "assignment-from-none",
+    "bad-exception-cause",
+    "bad-format-character",
+    "bad-reversed-sequence",
+    "bad-super-call",
+    "bad-thread-instantiation",
+    "catching-non-exception",
+    "comparison-with-callable",
+    "deprecated-class",
+    "dict-iter-missing-items",
+    "format-combined-specification",
+    "global-variable-undefined",
+    "import-error",
+    "inconsistent-mro",
+    "inherit-non-class",
+    "init-is-generator",
+    "invalid-class-object",
+    "invalid-enum-extension",
+    "invalid-envvar-value",
+    "invalid-format-returned",
+    "invalid-hash-returned",
+    "invalid-metaclass",
+    "invalid-overridden-method",
+    "invalid-repr-returned",
+    "invalid-sequence-index",
+    "invalid-slice-index",
+    "invalid-slots",
+    "invalid-slots-object",
+    "invalid-star-assignment-target",
+    "invalid-str-returned",
+    "invalid-unary-operand-type",
+    "invalid-unicode-codec",
+    "isinstance-second-argument-not-valid-type",
+    "method-hidden",
+    "misplaced-format-function",
+    "missing-format-argument-key",
+    "missing-format-attribute",
+    "missing-kwoa",
+    "no-member",
+    "no-value-for-parameter",
+    "non-iterator-returned",
+    "non-str-assignment-to-dunder-name",
+    "nonlocal-and-global",
+    "not-a-mapping",
+    "not-an-iterable",
+    "not-async-context-manager",
+    "not-callable",
+    "not-context-manager",
+    "overridden-final-method",
+    "raising-bad-type",
+    "raising-non-exception",
+    "redundant-keyword-arg",
+    "relative-beyond-top-level",
+    "self-cls-assignment",
+    "signature-differs",
+    "star-needs-assignment-target",
+    "subclassed-final-class",
+    "super-without-brackets",
+    "too-many-function-args",
+    "typevar-double-variance",
+    "typevar-name-mismatch",
+    "unbalanced-dict-unpacking",
+    "unbalanced-tuple-unpacking",
+    "unexpected-keyword-arg",
+    "unhashable-member",
+    "unpacking-non-sequence",
+    "unsubscriptable-object",
+    "unsupported-assignment-operation",
+    "unsupported-binary-operation",
+    "unsupported-delete-operation",
+    "unsupported-membership-test",
+    "used-before-assignment",
+    "using-final-decorator-in-unsupported-version",
+    "wrong-exception-operation",
+]
+enable = [
+    "useless-suppression",
+    "use-symbolic-message-instead",
 ]
 
-[tool.pylint.REPORTS]
-score = false
+[tool.pylint.TYPING]
+runtime-typing = false
 
-[tool.pylint.SIMILARITIES]
-# Minimum lines number of a similarity.
-# We set this higher because of some cases where V2 and V3 functionality are
-# similar, but abstracting them isn't feasible.
-min-similarity-lines = 8
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
-# Ignore comments when computing similarities.
-ignore-comments = true
+[tool.ruff.lint]
+select = [
+    "ALL"
+]
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "D202",    # No blank lines allowed after function docstring
+    "D203",    # 1 blank line required before class docstring
+    "PLR0913", # This is subjective
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT012",   # `pytest.raises()` block should contain a single simple statement
+    "TCH",     # flake8-type-checking
 
-# Ignore imports when computing similarities.
-ignore-imports = true
+    # May conflict with the formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "aioguardian",
+    "examples",
+    "tests",
+]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"aioambient/util/climate_utils.py" = [
+    "PLR2004",  # Climate utils utilize a ton of inline constants
+]
+"tests/*" = [
+    "ARG001",   # Tests ofen have unused arguments
+    "FBT001",   # Test fixtures may be boolean values
+    "PLR2004",  # Checking for magic values in tests isn't helpful
+    "S101",     # Assertions are fine in tests
+    "SLF001",   # We'll access a lot of private third-party members in tests
+]
 
 [tool.vulture]
 min_confidence = 80

--- a/tests/commands/iot/test_publish_state.py
+++ b/tests/commands/iot/test_publish_state.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("publish_state_failure_response.json").encode()],
@@ -18,7 +18,9 @@ async def test_publish_state_failure(mock_datagram_client: MagicMock) -> None:
     """Test the publish_state command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client, pytest.raises(CommandError) as err:
         async with Client("192.168.1.100") as client:
@@ -31,7 +33,7 @@ async def test_publish_state_failure(mock_datagram_client: MagicMock) -> None:
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("publish_state_success_response.json").encode()],
@@ -40,7 +42,9 @@ async def test_publish_state_success(mock_datagram_client: MagicMock) -> None:
     """Test the publish_state command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/sensor/test_pair_dump.py
+++ b/tests/commands/sensor/test_pair_dump.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("pair_dump_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_pair_dump_failure(mock_datagram_client: MagicMock) -> None:
     """Test the pair_dump command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_pair_dump_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("pair_dump_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_pair_dump_success(mock_datagram_client: MagicMock) -> None:
     """Test the pair_dump command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/sensor/test_pair_sensor.py
+++ b/tests/commands/sensor/test_pair_sensor.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("pair_sensor_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_pair_sensor_failure(mock_datagram_client: MagicMock) -> None:
     """Test the pair_sensor command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,12 +32,14 @@ async def test_pair_sensor_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_pair_sensor_invalid_uid(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid UID throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -48,7 +52,7 @@ async def test_pair_sensor_invalid_uid(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("pair_sensor_success_response.json").encode()]
 )
@@ -56,7 +60,9 @@ async def test_pair_sensor_success(mock_datagram_client: MagicMock) -> None:
     """Test the pair_sensor command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/sensor/test_paired_sensor_status.py
+++ b/tests/commands/sensor/test_paired_sensor_status.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("paired_sensor_status_failure_3_response.json").encode()],
@@ -20,7 +20,9 @@ async def test_paired_sensor_status_failure_not_paired(
     """Test the paired_sensor_status command failing because it isn't paired.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -33,7 +35,7 @@ async def test_paired_sensor_status_failure_not_paired(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("paired_sensor_status_failure_5_response.json").encode()],
@@ -44,7 +46,9 @@ async def test_paired_sensor_status_failure_error_loading(
     """Test the paired_sensor_status command failing because of a loading error.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -57,14 +61,16 @@ async def test_paired_sensor_status_failure_error_loading(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_paired_sensor_status_invalid_uid(
     mock_datagram_client: MagicMock,
 ) -> None:
     """Test that an invalid UID throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -77,7 +83,7 @@ async def test_paired_sensor_status_invalid_uid(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("paired_sensor_status_success_response.json").encode()],
@@ -88,7 +94,9 @@ async def test_paired_sensor_status_dump_success(
     """Test the pair_dump command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/sensor/test_unpair_sensor.py
+++ b/tests/commands/sensor/test_unpair_sensor.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("unpair_sensor_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_unpair_sensor_failure(mock_datagram_client: MagicMock) -> None:
     """Test the unpair_sensor command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,12 +32,14 @@ async def test_unpair_sensor_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_unpair_sensor_invalid_uid(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid UID throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -48,7 +52,7 @@ async def test_unpair_sensor_invalid_uid(mock_datagram_client: MagicMock) -> Non
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("unpair_sensor_success_response.json").encode()]
 )
@@ -56,7 +60,9 @@ async def test_unpair_sensor_success(mock_datagram_client: MagicMock) -> None:
     """Test the unpair_sensor command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/system/test_diagnostics.py
+++ b/tests/commands/system/test_diagnostics.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("diagnostics_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_diagnostics_failure(mock_datagram_client: MagicMock) -> None:
     """Test the diagnostics command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_diagnostics_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("diagnostics_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_diagnostics_success(mock_datagram_client: MagicMock) -> None:
     """Test the diagnostics command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/system/test_factory_reset.py
+++ b/tests/commands/system/test_factory_reset.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("factory_reset_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_factory_reset_failure(mock_datagram_client: MagicMock) -> None:
     """Test the factory_reset command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_factory_reset_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("factory_reset_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_factory_reset_success(mock_datagram_client: MagicMock) -> None:
     """Test the factory_reset command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/system/test_onboard_sensor_status.py
+++ b/tests/commands/system/test_onboard_sensor_status.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("onboard_sensor_status_success_response.json").encode()],
@@ -18,7 +18,9 @@ async def test_onboard_sensor_status_success(mock_datagram_client: MagicMock) ->
     """Test the onboard_sensor_status command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
@@ -29,7 +31,7 @@ async def test_onboard_sensor_status_success(mock_datagram_client: MagicMock) ->
         assert onboard_sensor_status["data"] == {"temperature": 71, "wet": False}
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("onboard_sensor_status_failure_response.json").encode()],
@@ -38,7 +40,9 @@ async def test_onboard_sensor_status_failure(mock_datagram_client: MagicMock) ->
     """Test the onboard_sensor_status command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:

--- a/tests/commands/system/test_ping.py
+++ b/tests/commands/system/test_ping.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("ping_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_ping_failure(mock_datagram_client: MagicMock) -> None:
     """Test a failed ping of the device.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_ping_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("ping_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_ping_success(mock_datagram_client: MagicMock) -> None:
     """Test the ping command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
@@ -48,7 +52,7 @@ async def test_ping_success(mock_datagram_client: MagicMock) -> None:
         assert ping_response["data"] == {"uid": "ABCDEF123456"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("ping_success_silent_response.json").encode()]
 )
@@ -56,7 +60,9 @@ async def test_ping_silent_success(mock_datagram_client: MagicMock) -> None:
     """Test the ping command succeeding while silent.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/system/test_reboot.py
+++ b/tests/commands/system/test_reboot.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("reboot_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_reboot_failure(mock_datagram_client: MagicMock) -> None:
     """Test the reboot command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_reboot_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("reboot_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_reboot_success(mock_datagram_client: MagicMock) -> None:
     """Test the reboot command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/system/test_upgrade_firmware.py
+++ b/tests/commands/system/test_upgrade_firmware.py
@@ -9,7 +9,7 @@ from aioguardian.errors import GuardianError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("upgrade_firmware_success_response.json").encode()],
@@ -20,7 +20,9 @@ async def test_upgrade_firmware_custom_parameters(
     """Test that valid custom parameters work.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
@@ -32,14 +34,16 @@ async def test_upgrade_firmware_custom_parameters(
         assert upgrade_firmware_response["status"] == "ok"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_upgrade_firmware_invalid_filename(
     mock_datagram_client: MagicMock,
 ) -> None:
     """Test that an invalid firmware filename throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(GuardianError) as err:
@@ -54,12 +58,14 @@ async def test_upgrade_firmware_invalid_filename(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_upgrade_firmware_invalid_port(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid firmware port throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(GuardianError) as err:
@@ -74,12 +80,14 @@ async def test_upgrade_firmware_invalid_port(mock_datagram_client: MagicMock) ->
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_upgrade_firmware_invalid_url(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid firmware URL throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(GuardianError) as err:
@@ -92,7 +100,7 @@ async def test_upgrade_firmware_invalid_url(mock_datagram_client: MagicMock) -> 
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response",
     [load_fixture("upgrade_firmware_success_response.json").encode()],
@@ -101,7 +109,9 @@ async def test_upgrade_firmware_success(mock_datagram_client: MagicMock) -> None
     """Test the upgrade_firmware command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/valve/test_close.py
+++ b/tests/commands/valve/test_close.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_close_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_close_failure(mock_datagram_client: MagicMock) -> None:
     """Test the valve_close command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -27,7 +29,7 @@ async def test_close_failure(mock_datagram_client: MagicMock) -> None:
         assert str(err.value) == "VALVE_CLOSE command failed: valve_already_closed"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_close_success_response.json").encode()]
 )
@@ -35,7 +37,9 @@ async def test_close_success(mock_datagram_client: MagicMock) -> None:
     """Test the valve_close command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/valve/test_halt.py
+++ b/tests/commands/valve/test_halt.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_halt_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_halt_failure(mock_datagram_client: MagicMock) -> None:
     """Test the valve_halt command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -27,7 +29,7 @@ async def test_halt_failure(mock_datagram_client: MagicMock) -> None:
         assert str(err.value) == "VALVE_HALT command failed: valve_already_stopped"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_halt_success_response.json").encode()]
 )
@@ -35,8 +37,10 @@ async def test_halt_success(caplog: Mock, mock_datagram_client: MagicMock) -> No
     """Test the valve_halt command succeeding.
 
     Args:
+    ----
         caplog: A mocked logging facility.
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/valve/test_open.py
+++ b/tests/commands/valve/test_open.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_open_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_open_failure(mock_datagram_client: MagicMock) -> None:
     """Test the valve_open command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -27,7 +29,7 @@ async def test_open_failure(mock_datagram_client: MagicMock) -> None:
         assert str(err.value) == "VALVE_OPEN command failed: valve_moving"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_open_success_response.json").encode()]
 )
@@ -35,7 +37,9 @@ async def test_open_success(mock_datagram_client: MagicMock) -> None:
     """Test the valve_open command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/valve/test_reset.py
+++ b/tests/commands/valve/test_reset.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_reset_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_reset_failure(mock_datagram_client: MagicMock) -> None:
     """Test the valve_reset command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_reset_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_reset_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_reset_success(mock_datagram_client: MagicMock) -> None:
     """Test the valve_reset command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/valve/test_status.py
+++ b/tests/commands/valve/test_status.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_status_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_status_failure(mock_datagram_client: MagicMock) -> None:
     """Test the valve_status command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_status_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("valve_status_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_status_success(mock_datagram_client: MagicMock) -> None:
     """Test the valve_status command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_configure.py
+++ b/tests/commands/wifi/test_configure.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError, GuardianError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_configure_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_configure_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_configure command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,12 +32,14 @@ async def test_configure_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_configure_invalid_password(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid password throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(GuardianError) as err:
@@ -51,12 +55,14 @@ async def test_configure_invalid_password(mock_datagram_client: MagicMock) -> No
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_configure_invalid_ssid(mock_datagram_client: MagicMock) -> None:
     """Test that an invalid SSID throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(GuardianError) as err:
@@ -71,7 +77,7 @@ async def test_configure_invalid_ssid(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_configure_success_response.json").encode()]
 )
@@ -79,7 +85,9 @@ async def test_configure_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_configure command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_disable_ap.py
+++ b/tests/commands/wifi/test_disable_ap.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_disable_ap_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_disable_ap_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_disable_ap command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_disable_ap_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_disable_ap_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_disable_ap_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_disable_ap command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_enable_ap.py
+++ b/tests/commands/wifi/test_enable_ap.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_enable_ap_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_enable_ap_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_enable_ap command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -30,7 +32,7 @@ async def test_enable_ap_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_enable_ap_success_response.json").encode()]
 )
@@ -38,7 +40,9 @@ async def test_enable_ap_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_enable_ap command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_list.py
+++ b/tests/commands/wifi/test_list.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_list_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_list_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_list command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_list_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_list_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_list_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_list command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:
@@ -60,7 +64,7 @@ async def test_list_success(mock_datagram_client: MagicMock) -> None:
         }
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_list_success_response.json").encode()]
 )
@@ -68,7 +72,9 @@ async def test_list_success_cached(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_list command succeeding after a cache.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_reset.py
+++ b/tests/commands/wifi/test_reset.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_reset_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_reset_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_reset command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_reset_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_reset_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_reset_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_reset command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_scan.py
+++ b/tests/commands/wifi/test_scan.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_scan_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_scan_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_scan command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_scan_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_scan_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_scan_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_scan command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/commands/wifi/test_status.py
+++ b/tests/commands/wifi/test_status.py
@@ -9,7 +9,7 @@ from aioguardian.errors import CommandError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_status_failure_response.json").encode()]
 )
@@ -17,7 +17,9 @@ async def test_status_failure(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_status command failing.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         with pytest.raises(CommandError) as err:
@@ -29,7 +31,7 @@ async def test_status_failure(mock_datagram_client: MagicMock) -> None:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("wifi_status_success_response.json").encode()]
 )
@@ -37,7 +39,9 @@ async def test_status_success(mock_datagram_client: MagicMock) -> None:
     """Test the wifi_status command succeeding.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,17 +1,20 @@
 """Define common test utilities."""
 
-import os
+from pathlib import Path
 
 
 def load_fixture(filename: str) -> str:
     """Load a fixture.
 
     Args:
+    ----
         filename: The filename of the fixtures/ file to load.
 
     Returns:
+    -------
         A string containing the contents of the file.
+
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
-    with open(path, encoding="utf-8") as fptr:
+    path = Path(f"{Path(__file__).parent}/fixtures/{filename}")
+    with Path.open(path, encoding="utf-8") as fptr:
         return fptr.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,10 @@ import pytest
 def command_response() -> MagicMock:
     """Define a fixture for the JSON response payload of a command.
 
-    Returns:
+    Returns
+    -------
         A mocked command response.
+
     """
     return MagicMock()
 
@@ -22,7 +24,9 @@ def mock_datagram_client(recv_response: AsyncMock) -> Generator:
     """Define a mocked datagram client.
 
     Args:
+    ----
         recv_response: A mocked instance of a socket recv operation.
+
     """
     mock_datagram_client = MagicMock()
     mock_datagram_client.connect = AsyncMock()
@@ -38,8 +42,10 @@ def mock_datagram_client(recv_response: AsyncMock) -> Generator:
 def recv_response(command_response: MagicMock, remote_addr_response: str) -> AsyncMock:
     """Define a response from the socket.
 
-    Returns:
+    Returns
+    -------
         A mocked instance of a socket recv operation.
+
     """
     return AsyncMock(return_value=(command_response, remote_addr_response))
 
@@ -48,7 +54,9 @@ def recv_response(command_response: MagicMock, remote_addr_response: str) -> Asy
 def remote_addr_response() -> str:
     """Define an IP address for the Guardian device.
 
-    Returns:
+    Returns
+    -------
         A response for getting the valve's remote IP address.
+
     """
     return "192.168.1.100"

--- a/tests/helpers/test_command.py
+++ b/tests/helpers/test_command.py
@@ -10,7 +10,7 @@ from aioguardian.helpers.command import (
 )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_command_from_code() -> None:
     """Test the get_command_from_code helper."""
     real_command = get_command_from_code(0)
@@ -21,7 +21,7 @@ async def test_get_command_from_code() -> None:
     assert str(err.value) == "Unknown command code: 99999"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_command_from_name() -> None:
     """Test the get_command_from_name helper."""
     real_command = get_command_from_name("SYSTEM_PING")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,13 +10,15 @@ from aioguardian.errors import SocketError
 from tests.common import load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize("recv_response", [AsyncMock(side_effect=asyncio.TimeoutError)])
 async def test_command_timeout(mock_datagram_client: MagicMock) -> None:
     """Test that a timeout during command execution throws an exception.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client, patch("asyncio.sleep"):
         with pytest.raises(SocketError) as err:
@@ -26,14 +28,16 @@ async def test_command_timeout(mock_datagram_client: MagicMock) -> None:
         assert str(err.value) == "SYSTEM_PING command timed out"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_command_timeout_successful_retry(
     mock_datagram_client: MagicMock,
 ) -> None:
     """Test that a timeout with a successful retry works.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client, patch("asyncio.sleep"):
         mock_datagram_client.recv.side_effect = [
@@ -49,7 +53,7 @@ async def test_command_timeout_successful_retry(
         assert ping_response["data"]["uid"] == "ABCDEF123456"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_command_without_socket_connect() -> None:
     """Test that executing a command without an open connection throws an exception."""
     client = Client("192.168.1.100")
@@ -59,7 +63,7 @@ async def test_command_without_socket_connect() -> None:
     assert str(err.value) == "You aren't connected to the device yet"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_connect_timeout() -> None:
     """Test that a timeout during connection throws an exception."""
     with patch("asyncio_dgram.connect", AsyncMock(side_effect=asyncio.TimeoutError)):
@@ -70,7 +74,7 @@ async def test_connect_timeout() -> None:
         assert str(err.value) == "Connection to device timed out"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "command_response", [load_fixture("ping_success_response.json").encode()]
 )
@@ -78,7 +82,9 @@ async def test_raw_command_success(mock_datagram_client: MagicMock) -> None:
     """Test a successful raw command.
 
     Args:
+    ----
         mock_datagram_client: A mocked UDP client.
+
     """
     with mock_datagram_client:
         async with Client("192.168.1.100") as client:


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses more of `ruff`'s ruleset, which allows us to (a) be more conforming across the board, (b) eliminate redundant `pylint` and `mypy` checks, and (c) remove several redundant `pre-commit` hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
